### PR TITLE
Validate corelibraries path before adding it to the dll search path

### DIFF
--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -768,8 +768,10 @@ LoadStartHost(
     nativeDllSearchDirs.append(W(";"));
     nativeDllSearchDirs.append(managedAssemblyDirectory);
 
-    nativeDllSearchDirs.append(W(";"));
-    nativeDllSearchDirs.append(coreLibraries);
+    if (wcslen(coreLibraries) != 0) {
+        nativeDllSearchDirs.append(W(";"));
+        nativeDllSearchDirs.append(coreLibraries);
+    }
     nativeDllSearchDirs.append(W(";"));
     nativeDllSearchDirs.append(hostEnvironment.m_coreCLRDirectoryPath);
 
@@ -814,8 +816,9 @@ LoadStartHost(
         tpaList = managedAssemblyFullName;
         tpaList.append(W(";"));
     }
-
-    tpaList.append(hostEnvironment.GetTpaList(coreLibraries));
+    if (wcslen(coreLibraries) != 0) {
+        tpaList.append(hostEnvironment.GetTpaList(coreLibraries));
+    }
     tpaList.append(hostEnvironment.GetTpaList(coreRoot));
 
     //-------------------------------------------------------------


### PR DESCRIPTION
Check if the coreLibraries path is not empty before trying to add it to the CoreCLR native dll search path and the TPA list