### PR TITLE
Handle adding the same bath to the TPA list better

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CoreHook.Host
 
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/unknownv2/CoreHook.Host/blob/master/LICENSE)
+
 A library for hosting .NET Core with [CoreHook](https://github.com/unknownv2/CoreHook) in an unmanaged application on Linux, macOS, and Windows.
 
 ## Build status

--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -292,30 +292,29 @@ public:
     // Returns the semicolon-separated list of paths to runtime dlls that are considered trusted.
     // On first call, scans the coreclr directory for dlls and adds them all to the list.
     const WCHAR * GetTpaList(const WCHAR * coreLibsPath) {
+        const WCHAR *rgTPAExtensions[] = {
+            // Probe for .ni.dll first so that it's preferred
+            // if ni and il coexist in the same dir
+            W("*.ni.dll"),
+            W("*.dll"),
+            W("*.ni.exe"),
+            W("*.exe"),
+            W("*.ni.winmd"),
+            W("*.winmd")
+        };
         if (m_tpaList.empty()) {
-            const WCHAR *rgTPAExtensions[] = {
-                        // Probe for .ni.dll first so that it's preferred
-                        // if ni and il coexist in the same dir
-                        W("*.ni.dll"),        
-                        W("*.dll"),
-                        W("*.ni.exe"),
-                        W("*.exe"),
-                        W("*.ni.winmd"),
-                        W("*.winmd")
-            };
-
-            // Add files from %CORE_LIBRARIES% if specified
-            std::wstring coreLibraries;
-            if (coreLibsPath) {
-                coreLibraries.append(coreLibsPath);
-                coreLibraries.append(W("\\"));
-                AddFilesFromDirectoryToTPAList(coreLibraries, rgTPAExtensions, _countof(rgTPAExtensions));
-            }
-            if (coreLibraries.compare(m_coreCLRDirectoryPath) != 0) {
-                AddFilesFromDirectoryToTPAList(m_coreCLRDirectoryPath, rgTPAExtensions, _countof(rgTPAExtensions));
-            }
+            std::wstring coreCLRDirectoryPath = m_coreCLRDirectoryPath;
+            coreCLRDirectoryPath.append(W("\\"));
+            AddFilesFromDirectoryToTPAList(coreCLRDirectoryPath, rgTPAExtensions, _countof(rgTPAExtensions));
         }
-
+        // Add files from from coreLibsPath if it is a different path than our initial current root 
+        std::wstring coreLibraries;
+        coreLibraries.append(coreLibsPath);
+        if (coreLibraries.compare(m_coreCLRDirectoryPath) != 0) {
+            coreLibraries.append(W("\\"));
+            AddFilesFromDirectoryToTPAList(coreLibraries, rgTPAExtensions, _countof(rgTPAExtensions));
+        }
+        
         return m_tpaList.c_str();
     }
 


### PR DESCRIPTION
* Only add a path to the TPA list if it is not our default CoreCLR path to avoid adding the same paths multiple times
* Add a license badge for better visibility