### PR TITLE
API Update: Change CoreCLR initialize export method name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ A library for hosting .NET Core with [CoreHook](https://github.com/unknownv2/Cor
 
 ### Requirements
 
-* Visual Studio 2017
+* Visual Studio
 
 ### Visual Studio
 
-Building the DLL requires Visual Studio and there are two options: You can build the DLL by using the `Visual Studio IDE` or using `msbuild` within the `Developer Command Prompt` (it has been tested with `Visual Studio 2017` only).
+Building the DLL requires Visual Studio and there are two options: You can build the DLL by using the `Visual Studio IDE` or using `msbuild` within the `Developer Command Prompt` (the solution file is for `Visual Studio 2017`, for other versions see the [CMake section](##cmake)).
 
 You can choose a configuration (**Debug|Release**) and a platform (**X86|X64|ARM|ARM64**) and build. 
 
-An example for building the X64 `corerundll64.dll` in the Release configuration:
+An example for building the X64 `corerundll64.dll` in the `Release` configuration:
 
 ```
 msbuild Windows/corerundll.sln /p:Configuration=Release /p:Platform=x64
@@ -34,24 +34,7 @@ The build output DLL will be inside the `Windows` folder.
 
 ### CMake
 
-You can also build the library using CMake. For example, to build for the `X86` and `X64` architectures:
-
-```
-cd Windows
-mkdir build32
-mkdir build64
-cd build32
-cmake -G "Visual Studio 15 2017" ../
-cd ../
-cd build64
-cmake -G "Visual Studio 15 2017 Win64" ../
-cd ../
-cmake --build build32 --config Debug
-cmake --build build32 --config Release
-cmake --build build64 --config Debug
-cmake --build build64 --config Release
-```
-
+You can also build the library using CMake. You can run the `win-vs-2017.bat` file to build for the `x86` and `x64` architectures. This also gives you the option to generate and build with an older version of `Visual Studio` such as `VS 2015` or `VS 2013`.
 
 ### Binary Releases 
  You can also download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Host/releases).

--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -162,7 +162,11 @@ public:
 
         if (m_coreCLRModule) {
 
+            // Save the directory that CoreCLR was found in
+            GetModuleFileNameWrapper(m_coreCLRModule, m_coreCLRDirectoryPath);
+
             // Search for the last backslash and terminate it there to keep just the directory path with trailing slash
+
             std::size_t lastBackslash = m_coreCLRDirectoryPath.find_last_of(W('\\'));
             m_coreCLRDirectoryPath.resize(lastBackslash);
         }
@@ -676,12 +680,12 @@ UnloadStopHost (
 }
 
 BOOLEAN
-LoadStartHost(
+StartHost(
     IN CONST INT32   argc,
     IN CONST WCHAR   *argv[],
     IN       Logger  &log,
     IN CONST BOOLEAN waitForDebugger,
-    _Inout_  LONG   &exitCode,
+    _Inout_  LONG    &exitCode,
     IN CONST WCHAR   *coreRoot,
     IN CONST WCHAR   *coreLibraries
     )
@@ -965,10 +969,9 @@ ValidateBinaryLoaderArgs (
     return E_INVALIDARG;
 }
 
-// Load a .NET Application or Library Assembly into the Host Application
-DllApi
+// Start the .NET Core runtime with an application path
 DWORD
-StartCLRAndLoadAssembly (
+StartCoreCLRInternal (
     IN CONST WCHAR   *dllPath,
     IN CONST BOOLEAN verbose,
     IN CONST BOOLEAN waitForDebugger,
@@ -996,7 +999,7 @@ StartCLRAndLoadAssembly (
         const DWORD paramCount = 1;
 
         const BOOLEAN success =
-            LoadStartHost(
+            StartHost(
               paramCount,
               params,
               *log,
@@ -1012,12 +1015,12 @@ StartCLRAndLoadAssembly (
 
 DllApi
 VOID
-LoadAssembly (
+StartCoreCLR(
     IN CONST BinaryLoaderArgs *args
     )
 {
     if (SUCCEEDED(ValidateBinaryLoaderArgs(args))) {
-        StartCLRAndLoadAssembly(
+        StartCoreCLRInternal(
             args->BinaryFilePath,
             args->Verbose,
             args->WaitForDebugger,
@@ -1042,6 +1045,7 @@ ExecuteAssemblyFunction (
     }
 }
 
+// Shutdown the .NET Core runtime
 DllApi
 VOID
 UnloadRunTime(

--- a/Windows/src/corerundll/corerundll.h
+++ b/Windows/src/corerundll/corerundll.h
@@ -52,34 +52,24 @@ struct RemoteEntryInfo
 
 // DLL exports used for starting, executing in, and stopping the .NET Core runtime
 
-// Stop the .NET Core host in the current application
+
+// Host the .NET Core runtime in the current application
 DllApi
 VOID
-UnloadRunTime(
-    VOID
+StartCoreCLR(
+    IN CONST BinaryLoaderArgs *args
 );
 
-// Execute a function in a .NET assembly that has been loaded in the .NET Core runtime
+// Execute a function located in a .NET assembly
 DllApi
 VOID
 ExecuteAssemblyFunction(
     IN CONST AssemblyFunctionCall *args
 );
 
-// Load a .NET assembly into the .NET Core runtime
+// Stop the .NET Core host in the current application
 DllApi
 VOID
-LoadAssembly(
-    IN CONST BinaryLoaderArgs *args
-);
-
-// Host the .NET Core runtime in the current application and load a .NET assembly into the runtime
-DllApi
-DWORD
-StartCLRAndLoadAssembly(
-    IN CONST WCHAR   *dllPath,
-    IN CONST BOOLEAN verbose,
-    IN CONST BOOLEAN waitForDebugger,
-    IN CONST WCHAR   *coreRoot,
-    IN CONST WCHAR   *coreLibraries
+UnloadRunTime(
+    VOID
 );


### PR DESCRIPTION
* Change method name from `LoadAssembly` to `StartCoreCLR` to better reflect the function
* Fix a bug that stopped CoreCLR from starting by not getting the path of the CoreCLR root directory. It was accidentally removed during refactoring.
* Update readme on instructions for using CMake for older versions of Visual Studio