### PR TITLE
Update corerundll VC++ project and add a test project (google test)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ configuration:
   - Debug
   - Release
 
+before_build:
+  - nuget restore Windows\corerundll.sln
+
 build:
   project: Windows\corerundll.sln
   verbosity: detailed

--- a/Windows/corerundll.sln
+++ b/Windows/corerundll.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "corerundll", "src\corerundll\corerundll.vcxproj", "{56ECC22A-A4DB-409B-826E-D3637CC647E6}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "corerundll-test", "tests\corerundll-test\corerundll-test.vcxproj", "{1AB3F109-225A-41CC-A436-81333EFB7470}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM = Debug|ARM
@@ -33,6 +35,18 @@ Global
 		{56ECC22A-A4DB-409B-826E-D3637CC647E6}.Release|x64.Build.0 = Release|x64
 		{56ECC22A-A4DB-409B-826E-D3637CC647E6}.Release|x86.ActiveCfg = Release|Win32
 		{56ECC22A-A4DB-409B-826E-D3637CC647E6}.Release|x86.Build.0 = Release|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|ARM.ActiveCfg = Debug|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|ARM64.ActiveCfg = Debug|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|x64.ActiveCfg = Debug|x64
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|x64.Build.0 = Debug|x64
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|x86.ActiveCfg = Debug|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Debug|x86.Build.0 = Debug|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|ARM.ActiveCfg = Release|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|ARM64.ActiveCfg = Release|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|x64.ActiveCfg = Release|x64
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|x64.Build.0 = Release|x64
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|x86.ActiveCfg = Release|Win32
+		{1AB3F109-225A-41CC-A436-81333EFB7470}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -144,7 +144,7 @@ public:
             *m_log << W("CORE_ROOT path was not set; skipping") << Logger::endl;
         }
 
-        // Try to load CoreCLR from the directory that coreRun is in
+        // Try to load CoreCLR from the host directory
         if (!m_coreCLRModule) {
             m_coreCLRModule = TryLoadCoreCLR(m_hostDirectoryPath);
         }
@@ -943,7 +943,7 @@ ValidateBinaryLoaderArgs (
     return E_INVALIDARG;
 }
 
-// Start the .NET Core runtime with an application path
+// Start the .NET Core runtime in the current application
 HRESULT
 StartCoreCLRInternal (
     IN CONST WCHAR   *dllPath,
@@ -953,7 +953,6 @@ StartCoreCLRInternal (
     IN CONST WCHAR   *coreLibraries
     )
 {
-    // Parse the options from the command line
     HRESULT exitCode = -1;
 
     auto log = GetLogger();
@@ -995,20 +994,22 @@ StartCoreCLR(
     return E_INVALIDARG;
 }
 
+// Execute a function located in a .NET assembly by creating a native delegate
 DllApi
-VOID
+HRESULT
 ExecuteAssemblyFunction (
     IN CONST AssemblyFunctionCall *args
     )
 {
     if (SUCCEEDED(ValidateAssemblyFunctionCallArgs(args))) {
 
-        ExecuteAssemblyClassFunction(*GetLogger(),
+        return ExecuteAssemblyClassFunction(*GetLogger(),
             args->Assembly,
             args->Class,
             args->Function,
             args->Arguments);
     }
+    return E_INVALIDARG;
 }
 
 // Shutdown the .NET Core runtime

--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -141,9 +141,7 @@ public:
         }
         else
         {
-            *m_log << W("CORE_ROOT not set; skipping") << Logger::endl;
-            *m_log << W("You can set the environment variable CORE_ROOT to point to the path") << Logger::endl;
-            *m_log << W("where CoreCLR.dll lives to help CoreRun.exe find it.") << Logger::endl;
+            *m_log << W("CORE_ROOT path was not set; skipping") << Logger::endl;
         }
 
         // Try to load CoreCLR from the directory that coreRun is in

--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -592,12 +592,12 @@ ExecuteAssemblyClassFunction (
     return hr;
 }
 
-BOOLEAN
+HRESULT
 UnloadStopHost (
     IN Logger &log
     )
 {
-    HRESULT hr;
+    HRESULT hr = E_HANDLE;
     int exitCode = -1;
 
     //-------------------------------------------------------------
@@ -616,7 +616,7 @@ UnloadStopHost (
 
         if (FAILED(hr)) {
             log << W("Failed to unload the AppDomain. ERRORCODE: ") << Logger::hresult << hr << Logger::endl;
-            return false;
+            return hr;
         }
 
         log << W("App domain unloaded exit value = ") << exitCode << Logger::endl;
@@ -630,7 +630,7 @@ UnloadStopHost (
 
         if (FAILED(hr)) {
             log << W("Failed to stop the host. ERRORCODE: ") << Logger::hresult << hr << Logger::endl;
-            return false;
+            return hr;
         }
 
         //-------------------------------------------------------------
@@ -645,7 +645,7 @@ UnloadStopHost (
 
     SetDomainId((DWORD)-1);
 
-    return true;
+    return hr;
 }
 
 BOOLEAN
@@ -1013,12 +1013,12 @@ ExecuteAssemblyFunction (
 
 // Shutdown the .NET Core runtime
 DllApi
-VOID
+HRESULT
 UnloadRunTime(
     VOID
     ) 
 {
-    UnloadStopHost(*GetLogger());
+    return UnloadStopHost(*GetLogger());
 }
 
 BOOLEAN

--- a/Windows/src/corerundll/corerundll.h
+++ b/Windows/src/corerundll/corerundll.h
@@ -78,7 +78,7 @@ StartCoreCLR(
 
 // Stop the .NET Core host in the current application
 DllApi
-VOID
+HRESULT
 UnloadRunTime(
     VOID
 );

--- a/Windows/src/corerundll/corerundll.h
+++ b/Windows/src/corerundll/corerundll.h
@@ -62,9 +62,9 @@ CreateAssemblyDelegate(
     _Inout_  PVOID  *pfnDelegate
 );
 
-// Execute a function located in a .NET assembly
+// Execute a function located in a .NET assembly by creating a native delegate
 DllApi
-VOID
+HRESULT
 ExecuteAssemblyFunction(
     IN CONST AssemblyFunctionCall *args
 );

--- a/Windows/src/corerundll/corerundll.h
+++ b/Windows/src/corerundll/corerundll.h
@@ -55,9 +55,19 @@ struct RemoteEntryInfo
 
 // Host the .NET Core runtime in the current application
 DllApi
-VOID
+HRESULT
 StartCoreCLR(
     IN CONST BinaryLoaderArgs *args
+);
+
+// Create a native function delegate for a function inside a .NET assembly
+DllApi
+HRESULT
+CreateAssemblyDelegate(
+    IN CONST WCHAR  *assembly,
+    IN CONST WCHAR  *type,
+    IN CONST WCHAR  *entry,
+    _Inout_  PVOID  *pfnDelegate
 );
 
 // Execute a function located in a .NET assembly

--- a/Windows/src/corerundll/corerundll.h
+++ b/Windows/src/corerundll/corerundll.h
@@ -52,14 +52,6 @@ struct RemoteEntryInfo
 
 // DLL exports used for starting, executing in, and stopping the .NET Core runtime
 
-
-// Host the .NET Core runtime in the current application
-DllApi
-HRESULT
-StartCoreCLR(
-    IN CONST BinaryLoaderArgs *args
-);
-
 // Create a native function delegate for a function inside a .NET assembly
 DllApi
 HRESULT
@@ -75,6 +67,13 @@ DllApi
 VOID
 ExecuteAssemblyFunction(
     IN CONST AssemblyFunctionCall *args
+);
+
+// Host the .NET Core runtime in the current application
+DllApi
+HRESULT
+StartCoreCLR(
+    IN CONST BinaryLoaderArgs *args
 );
 
 // Stop the .NET Core host in the current application

--- a/Windows/src/corerundll/corerundll.vcxproj
+++ b/Windows/src/corerundll/corerundll.vcxproj
@@ -46,7 +46,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{56ECC22A-A4DB-409B-826E-D3637CC647E6}</ProjectGuid>
     <RootNamespace>corerundll</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Windows/src/corerundll/corerundll.vcxproj
+++ b/Windows/src/corerundll/corerundll.vcxproj
@@ -60,6 +60,8 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+    <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -74,6 +76,8 @@
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+    <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -86,6 +90,8 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+    <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>    
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -100,6 +106,8 @@
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <WindowsSDKDesktopARMSupport>true</WindowsSDKDesktopARMSupport>
+    <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>    
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Windows/tests/corerundll-test/assembly-test.cpp
+++ b/Windows/tests/corerundll-test/assembly-test.cpp
@@ -1,0 +1,6 @@
+#include "pch.h"
+
+TEST(TestCaseName, TestName) {
+  EXPECT_EQ(1, 1);
+  EXPECT_TRUE(true);
+}

--- a/Windows/tests/corerundll-test/assembly-test.cpp
+++ b/Windows/tests/corerundll-test/assembly-test.cpp
@@ -1,6 +1,37 @@
 #include "pch.h"
+#include "../../src/corerundll/corerundll.h"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
+TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
+
+    PCWSTR dotnetAssemblyName = L"Calculator.dll";
+    static const wchar_t *coreCLRInstallDirectory = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.5";
+
+    BinaryLoaderArgs binaryLoaderArgs = { 0 };
+    AssemblyFunctionCall assemblyFunctionCall = { 0 };
+    binaryLoaderArgs.Verbose = true;
+    binaryLoaderArgs.WaitForDebugger = false;
+    wcscpy_s(binaryLoaderArgs.BinaryFilePath, MAX_PATH, dotnetAssemblyName);
+
+    WCHAR coreCLRInstallPath[MAX_PATH];
+    ::ExpandEnvironmentStringsW(coreCLRInstallDirectory, coreCLRInstallPath, MAX_PATH);
+
+    wcscpy_s(binaryLoaderArgs.CoreRootPath, MAX_PATH, coreCLRInstallPath);
+
+    EXPECT_EQ(NOERROR, StartCoreCLR(&binaryLoaderArgs));
+
+    typedef int (STDMETHODCALLTYPE AddMethodFp)(const int a, const int b);
+    AddMethodFp *pfnAddDelegate = NULL;
+
+    EXPECT_EQ(NO_ERROR,
+        CreateAssemblyDelegate(
+            L"Calculator",
+            L"Calculator.Calculator",
+            L"Add",
+            reinterpret_cast<PVOID*>(&pfnAddDelegate)));
+
+    const int integerA = 1;
+    const int integerB = 2;
+    const int integerResult = integerA + integerB;
+
+    EXPECT_EQ(integerResult, pfnAddDelegate(integerA, integerB));
 }

--- a/Windows/tests/corerundll-test/assembly-test.cpp
+++ b/Windows/tests/corerundll-test/assembly-test.cpp
@@ -3,8 +3,21 @@
 
 TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
 
-    PCWSTR dotnetAssemblyName = L"Calculator.dll";
-    static const wchar_t *coreCLRInstallDirectory = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.5";
+    // Assembly file name for getting base library path 
+    // that is given to the .NET Core host when starting it
+    PCWSTR dotnetAssemblyName =     L"Calculator.dll";
+    // Assembly name used for delegate resolving
+    PCWSTR assemblyName =           L"Calculator";
+    // Class name used for delegate resolving
+    PCWSTR assemblyType =           L"Calculator.Calculator";
+    // Static class function names used for delegate resolving
+    PCWSTR assemblyEntryAdd =       L"Add";
+    PCWSTR assemblyEntrySubtract =  L"Subtract";
+    PCWSTR assemblyEntryMultiply =  L"Multiply";
+    PCWSTR assemblyEntryDivide =    L"Divide";
+
+    PCWSTR coreCLRInstallDirectory
+        = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.5";
 
     BinaryLoaderArgs binaryLoaderArgs = { 0 };
     AssemblyFunctionCall assemblyFunctionCall = { 0 };
@@ -20,18 +33,61 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(NOERROR, StartCoreCLR(&binaryLoaderArgs));
 
     typedef int (STDMETHODCALLTYPE AddMethodFp)(const int a, const int b);
-    AddMethodFp *pfnAddDelegate = NULL;
+    AddMethodFp *pfnMethodDelegate = NULL;
 
-    EXPECT_EQ(NO_ERROR,
+    // Test the 'int Add(int a, int b) => a + b;' method
+    EXPECT_EQ(NOERROR,
         CreateAssemblyDelegate(
-            L"Calculator",
-            L"Calculator.Calculator",
-            L"Add",
-            reinterpret_cast<PVOID*>(&pfnAddDelegate)));
+            assemblyName,
+            assemblyType,
+            assemblyEntryAdd,
+            reinterpret_cast<PVOID*>(&pfnMethodDelegate)));
 
+    // Our simple test values
     const int integerA = 1;
     const int integerB = 2;
-    const int integerResult = integerA + integerB;
+    const int integerAddResult = integerA + integerB;
 
-    EXPECT_EQ(integerResult, pfnAddDelegate(integerA, integerB));
+    EXPECT_EQ(integerAddResult, pfnMethodDelegate(integerA, integerB));
+
+    // Test the 'int Subtract(int a, int b) => b - a;' method
+    pfnMethodDelegate = NULL;
+
+    EXPECT_EQ(NOERROR,
+        CreateAssemblyDelegate(
+            assemblyName,
+            assemblyType,
+            assemblyEntrySubtract,
+            reinterpret_cast<PVOID*>(&pfnMethodDelegate)));
+
+    const int integerSubResult = integerB - integerA;
+    EXPECT_EQ(integerSubResult, pfnMethodDelegate(integerA, integerB));
+
+    // Test the 'int Multiply(int a, int b) => a * b;' method
+    pfnMethodDelegate = NULL;
+
+    EXPECT_EQ(NOERROR,
+        CreateAssemblyDelegate(
+            assemblyName,
+            assemblyType,
+            assemblyEntryMultiply,
+            reinterpret_cast<PVOID*>(&pfnMethodDelegate)));
+
+    const int integerMulResult = integerA * integerB;
+    EXPECT_EQ(integerMulResult, pfnMethodDelegate(integerA, integerB));
+
+    // Test the 'int Divide(int a, int b) => a / b;' method
+    pfnMethodDelegate = NULL;
+
+    EXPECT_EQ(NOERROR,
+        CreateAssemblyDelegate(
+            assemblyName,
+            assemblyType,
+            assemblyEntryDivide,
+            reinterpret_cast<PVOID*>(&pfnMethodDelegate)));
+
+    const int integerDivResult = integerA / integerB;
+    EXPECT_EQ(integerDivResult, pfnMethodDelegate(integerA, integerB));
+
+    EXPECT_EQ(NOERROR, UnloadRunTime());
 }

--- a/Windows/tests/corerundll-test/corerundll-test.vcxproj
+++ b/Windows/tests/corerundll-test/corerundll-test.vcxproj
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{1ab3f109-225a-41cc-a436-81333efb7470}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)bin.X64\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)bin.X64\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)bin.X86\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)bin.X86\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="assembly-test.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\corerundll\corerundll.vcxproj">
+      <Project>{56ecc22a-a4db-409b-826e-d3637cc647e6}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemDefinitionGroup />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+    </Link>
+  </ItemDefinitionGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.0\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+  </Target>
+</Project>

--- a/Windows/tests/corerundll-test/corerundll-test.vcxproj
+++ b/Windows/tests/corerundll-test/corerundll-test.vcxproj
@@ -95,6 +95,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <SupportJustMyCode>false</SupportJustMyCode>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Windows/tests/corerundll-test/packages.config
+++ b/Windows/tests/corerundll-test/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.0" targetFramework="native" />
+</packages>

--- a/Windows/tests/corerundll-test/pch.cpp
+++ b/Windows/tests/corerundll-test/pch.cpp
@@ -1,0 +1,6 @@
+//
+// pch.cpp
+// Include the standard header and generate the precompiled header.
+//
+
+#include "pch.h"

--- a/Windows/tests/corerundll-test/pch.h
+++ b/Windows/tests/corerundll-test/pch.h
@@ -1,0 +1,8 @@
+//
+// pch.h
+// Header for standard system include files.
+//
+
+#pragma once
+
+#include "gtest/gtest.h"


### PR DESCRIPTION
* Update the corerundll project to SDK 10.0.17134.0
* Refactor exported functions to return HRESULT error codes instead of nothing (return type VOID).
* Add a google test project to help guide development and improvements
* Update AppVeyor config to restore nuget references for the gtest library