### PR TITLE
test: Add C# class for testing corerundll

### DIFF
--- a/Windows/src/corerundll/corerundll.cpp
+++ b/Windows/src/corerundll/corerundll.cpp
@@ -552,7 +552,7 @@ ExecuteAssemblyClassFunction (
     MainMethodFp *pfnDelegate = NULL;
 
     if (SUCCEEDED((hr = CreateAssemblyDelegate(assembly, type, entry, (PVOID*)&pfnDelegate)))) {
-        RemoteEntryInfo entryInfo;
+        RemoteEntryInfo entryInfo = { 0 };
         entryInfo.HostPID = GetCurrentProcessId();
 
         auto remoteArgs = reinterpret_cast<const RemoteFunctionArgs*>(arguments);

--- a/Windows/src/corerundll/logger.cpp
+++ b/Windows/src/corerundll/logger.cpp
@@ -1,9 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-
-
 #include <stdio.h>
 #include <windows.h>
 #include "logger.h"
@@ -224,6 +218,15 @@ Logger& Logger::operator<< (unsigned long val) {
     return *this;
 }
 #endif
+
+Logger& Logger::operator<< (PVOID val) {
+    if (m_isEnabled) {
+        EnsurePrefixIsPrinted();
+
+        ::wprintf(W("%p"), val);
+    }
+    return *this;
+}
 
 Logger& Logger::operator<< (const wchar_t *val) {
     if (m_isEnabled) {

--- a/Windows/src/corerundll/logger.cpp
+++ b/Windows/src/corerundll/logger.cpp
@@ -1,7 +1,6 @@
-#include <stdio.h>
+#include <cstdio>
 #include <windows.h>
 #include "logger.h"
-//#include "palclr.h"
 
 void Logger::Enable() {
     m_isEnabled = true;
@@ -19,7 +18,7 @@ void print(const wchar_t *val) {
 
     wchar_t chunk[chunkSize];
 
-    auto valLength = ::wcslen(val);
+    const auto valLength = ::wcslen(val);
 
     for (size_t i = 0 ; i < valLength ; i += chunkSize) {
 

--- a/Windows/src/corerundll/logger.h
+++ b/Windows/src/corerundll/logger.h
@@ -1,10 +1,5 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-
 //
-// Logger for the CoreCLR host ccrun.
+// Logger for the CoreCLR host.
 // Relies on the SYSCRT and therefore cannot use C++ libraries.
 //
 
@@ -39,7 +34,9 @@ public:
 #ifdef _MSC_VER
     Logger& operator<< (long val);
     Logger& operator<< (unsigned long val);
+
 #endif
+    Logger& operator<< (PVOID val);
     Logger& operator<< (float val);
     Logger& operator<< (double val);
     Logger& operator<< (long double val);

--- a/Windows/src/corerundll/logger.h
+++ b/Windows/src/corerundll/logger.h
@@ -2,7 +2,7 @@
 // Logger for the CoreCLR host.
 // Relies on the SYSCRT and therefore cannot use C++ libraries.
 //
-
+#pragma once
 #include <string>
 
 #define W(str)  L##str

--- a/Windows/tests/corerundll-test/assembly-test.cpp
+++ b/Windows/tests/corerundll-test/assembly-test.cpp
@@ -15,6 +15,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     PCWSTR assemblyEntrySubtract =  L"Subtract";
     PCWSTR assemblyEntryMultiply =  L"Multiply";
     PCWSTR assemblyEntryDivide =    L"Divide";
+    PCWSTR assemblyEntryPoint =     L"Load";
 
     PCWSTR coreCLRInstallDirectory
         = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.5";
@@ -33,7 +34,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(NOERROR, StartCoreCLR(&binaryLoaderArgs));
 
     typedef int (STDMETHODCALLTYPE AddMethodFp)(const int a, const int b);
-    AddMethodFp *pfnMethodDelegate = NULL;
+    AddMethodFp *pfnMethodDelegate = nullptr;
 
     // Test the 'int Add(int a, int b) => a + b;' method
     EXPECT_EQ(NOERROR,
@@ -51,7 +52,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(integerAddResult, pfnMethodDelegate(integerA, integerB));
 
     // Test the 'int Subtract(int a, int b) => b - a;' method
-    pfnMethodDelegate = NULL;
+    pfnMethodDelegate = nullptr;
 
     EXPECT_EQ(NOERROR,
         CreateAssemblyDelegate(
@@ -64,7 +65,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(integerSubResult, pfnMethodDelegate(integerA, integerB));
 
     // Test the 'int Multiply(int a, int b) => a * b;' method
-    pfnMethodDelegate = NULL;
+    pfnMethodDelegate = nullptr;
 
     EXPECT_EQ(NOERROR,
         CreateAssemblyDelegate(
@@ -77,7 +78,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(integerMulResult, pfnMethodDelegate(integerA, integerB));
 
     // Test the 'int Divide(int a, int b) => a / b;' method
-    pfnMethodDelegate = NULL;
+    pfnMethodDelegate = nullptr;
 
     EXPECT_EQ(NOERROR,
         CreateAssemblyDelegate(
@@ -89,5 +90,22 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     const int integerDivResult = integerA / integerB;
     EXPECT_EQ(integerDivResult, pfnMethodDelegate(integerA, integerB));
 
+    typedef void (STDMETHODCALLTYPE MethodVoidDelegate)(const VOID* args);
+    MethodVoidDelegate *pfnMethodVoidDelegate = nullptr;
+    EXPECT_EQ(NOERROR,
+        CreateAssemblyDelegate(
+            assemblyName,
+            assemblyType,
+            assemblyEntryPoint,
+            reinterpret_cast<PVOID*>(&pfnMethodVoidDelegate)));
+
+    // Call the 'void Run(string paramPtr)' method
+    wcscpy_s(assemblyFunctionCall.Assembly, FunctionNameSize, assemblyName);
+    wcscpy_s(assemblyFunctionCall.Class, FunctionNameSize, assemblyType);
+    wcscpy_s(assemblyFunctionCall.Function, FunctionNameSize, assemblyEntryPoint);
+
+    ExecuteAssemblyFunction(&assemblyFunctionCall);
+
+    // Unload the AppDomain and stop the host
     EXPECT_EQ(NOERROR, UnloadRunTime());
 }

--- a/Windows/tests/dotnet/Calculator.cs
+++ b/Windows/tests/dotnet/Calculator.cs
@@ -3,7 +3,12 @@ namespace Calculator
 {
     public class Calculator
     {
-         /// <summary>
+        /// <summary>
+        /// Method called by the CoreHook host to initialize the hooking library.
+        /// </summary>
+        /// <param name="paramPtr">A pointer passed in as a hex string containing information about the hooking library.</param>
+        public static void Load(string paramPtr) => System.Diagnostics.Debug.WriteLine($"The parameter string was {paramPtr}.");
+        /// <summary>
         /// Add <paramref name="a"/> to <paramref name="b"/>.
         /// </summary>
         /// <param name="a"></param>

--- a/Windows/tests/dotnet/Calculator.cs
+++ b/Windows/tests/dotnet/Calculator.cs
@@ -1,0 +1,35 @@
+
+namespace Calculator
+{
+    public class Calculator
+    {
+         /// <summary>
+        /// Add <paramref name="a"/> to <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns><paramref name="a"/> plus <paramref name="b"/>.</returns>
+        public static int Add(int a, int b) => a + b;
+        /// <summary>
+        /// Subtract <paramref name="a"/> from <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns><paramref name="b"/> minus <paramref name="a"/>.</returns>
+        public static int Subtract(int a, int b) => b - a;
+        /// <summary>
+        /// Mulitply <paramref name="a"/> by <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns><paramref name="a"/> times <paramref name="b"/>.</returns>
+        public static int Multiply(int a, int b) => a * b;
+        /// <summary>
+        /// Divide <paramref name="a"/> by <paramref name="b"/>.
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <returns><paramref name="a"/> divied by <paramref name="b"/>.</returns>
+        public static int Divide(int a, int b) => a / b;
+    }
+}


### PR DESCRIPTION
*Added a C# Calculator testing class with several methods to test creating native C++ delegates with the corerundll library.

* Refactored the library to make it more consistent with C++ style coding as well, such as using 'nullptr' in place of 'NULL' and the auto specifier.