### PR TITLE
BREAKING CHANGE: Pass a pointer to the Load function instead of converting it to a string

### DIFF
--- a/build/msvc/corerundll-test.vcxproj
+++ b/build/msvc/corerundll-test.vcxproj
@@ -34,15 +34,19 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>$(SolutionDir)..\..\bin\$(PlatformTarget)\$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\$(ProjectName)\</IntDir>
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="../../tests/pch.h" />

--- a/src/corerundll.cpp
+++ b/src/corerundll.cpp
@@ -489,22 +489,6 @@ CreateStartupFlags (
     return initialFlags;
 }
 
-// Convert an integer value to it's hex string representation
-template <typename I>
-std::string
-ConvertToHexString (
-    I input, 
-    size_t hex_len = sizeof(I) << 1
-    )
-{
-    static const auto digits = "0123456789ABCDEF";
-    std::string hex_string(hex_len, '0');
-    for (size_t i = 0, j = (hex_len - 1) * 4; i < hex_len; ++i, j -= 4) {
-        hex_string[i] = digits[(input >> j) & 0x0f];
-    }
-    return hex_string;
-}
-
 // Create a native function delegate for a function inside a .NET assembly
 HRESULT
 CreateAssemblyDelegate(
@@ -561,11 +545,9 @@ ExecuteAssemblyClassFunction (
             entryInfo.Args.UserData = remoteArgs->UserData;
             entryInfo.Args.UserDataSize = remoteArgs->UserDataSize;
 
-            auto paramString = ConvertToHexString(reinterpret_cast<LONGLONG>(&entryInfo), 16);
+            log << W("Calling delegate function at ") << static_cast<PVOID>(pfnDelegate) << W(" with a parameter: ") << static_cast<PVOID>(&entryInfo)  << Logger::endl;
 
-            log << W("Calling delegate function at ") << static_cast<PVOID>(pfnDelegate) << W(" with a parameter") << Logger::endl;
-
-            pfnDelegate(paramString.c_str());
+            pfnDelegate(&entryInfo);
         }
         else {
             // No arguments were supplied to pass to the delegate function so pass an

--- a/tests/assembly-test.cpp
+++ b/tests/assembly-test.cpp
@@ -99,12 +99,12 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
             assemblyEntryPoint,
             reinterpret_cast<PVOID*>(&pfnMethodVoidDelegate)));
 
-    // Call the 'void Run(string paramPtr)' method
+    // Call the 'int Load(IntPtr remoteParameters)' method
     wcscpy_s(assemblyFunctionCall.Assembly, FunctionNameSize, assemblyName);
     wcscpy_s(assemblyFunctionCall.Class, FunctionNameSize, assemblyType);
     wcscpy_s(assemblyFunctionCall.Function, FunctionNameSize, assemblyEntryPoint);
 
-    ExecuteAssemblyFunction(&assemblyFunctionCall);
+    EXPECT_EQ(NOERROR, ExecuteAssemblyFunction(&assemblyFunctionCall));
 
     // Unload the AppDomain and stop the host
     EXPECT_EQ(NOERROR, UnloadRunTime());


### PR DESCRIPTION
The CoreLoad.Loader.Load function now takes an IntPtr parameter instead of a string parameter that is then parsed to an IntPtr. This means old hosts will no longer work and you will have to use the latest version past this point.

Changes:
* Use a separate intermediate directory for the corerundll-test project
* Add a test for the return value of ExecuteAssemblyFunction in the gtest project