### PR TITLE
test: Update CoreCLR install directory to latest version

### DIFF
--- a/tests/assembly-test.cpp
+++ b/tests/assembly-test.cpp
@@ -18,7 +18,7 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     PCWSTR assemblyEntryPoint =     L"Load";
 
     PCWSTR coreCLRInstallDirectory
-        = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.5";
+        = L"%programfiles%\\dotnet\\shared\\Microsoft.NETCore.App\\2.1.6";
 
     BinaryLoaderArgs binaryLoaderArgs = { 0 };
     AssemblyFunctionCall assemblyFunctionCall = { 0 };


### PR DESCRIPTION
Update directory used in the hosting test from version 2.1.5 to 2.1.6.