### PR TITLE
Change the DLL export name UnloadRunTime to UnloadRuntime

### DIFF
--- a/src/corerundll.cpp
+++ b/src/corerundll.cpp
@@ -949,7 +949,7 @@ ExecuteAssemblyFunction (
 // Shutdown the .NET Core runtime
 DllApi
 HRESULT
-UnloadRunTime(
+UnloadRuntime(
     VOID
     ) 
 {

--- a/src/corerundll.h
+++ b/src/corerundll.h
@@ -78,6 +78,6 @@ StartCoreCLR(
 // Stop the .NET Core host in the current application
 DllApi
 HRESULT
-UnloadRunTime(
+UnloadRuntime(
     VOID
 );

--- a/tests/assembly-test.cpp
+++ b/tests/assembly-test.cpp
@@ -106,5 +106,5 @@ TEST(TestCoreCLRHost, TestDotNetAssemblyExecution) {
     EXPECT_EQ(NOERROR, ExecuteAssemblyFunction(&assemblyFunctionCall));
 
     // Unload the AppDomain and stop the host
-    EXPECT_EQ(NOERROR, UnloadRunTime());
+    EXPECT_EQ(NOERROR, UnloadRuntime());
 }


### PR DESCRIPTION
Updating the spelling for one of the exports in the DLL and the test code.