### PR TITLE
Validate module export function arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 include_directories(${CORELOAD_INSTALL_INCLUDE_DIR})
 
 project(coreload_dll)
+add_definitions(-DCOREHOST_MAKE_DLL=1)
 if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
     add_definitions(-D_TARGET_X86_=1 -DCORELOAD_BITS=32)
     set(CORELOAD_DLL_NAME "coreload32")

--- a/build/msvc/coreload/coreload-dll.vcxproj
+++ b/build/msvc/coreload/coreload-dll.vcxproj
@@ -185,7 +185,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COREHOST_MAKE_DLL=1;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -200,7 +200,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COREHOST_MAKE_DLL=1;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -215,7 +215,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COREHOST_MAKE_DLL=1;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -230,7 +230,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COREHOST_MAKE_DLL=1;_DEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -247,7 +247,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COREHOST_MAKE_DLL=1;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -266,7 +266,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;COREHOST_MAKE_DLL=1;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -285,7 +285,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COREHOST_MAKE_DLL=1;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -304,7 +304,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>COREHOST_MAKE_DLL=1;NDEBUG;CORELOADDLL_EXPORTS;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\..\..\src\coreload\common;..\..\..\src\coreload\logging;..\..\..\src\coreload\json\casablanca\include;..\..\..\src\coreload;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/build/msvc/coreload/coreload-test.vcxproj
+++ b/build/msvc/coreload/coreload-test.vcxproj
@@ -104,7 +104,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;COREHOST_MAKE_DLL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -138,7 +138,7 @@
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>X64;_DEBUG;_CONSOLE;COREHOST_MAKE_DLL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -171,7 +171,7 @@
     <ClCompile>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;COREHOST_MAKE_DLL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -205,7 +205,7 @@
     <ClCompile>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>X64;NDEBUG;_CONSOLE;COREHOST_MAKE_DLL=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/src/coreload/arguments.cc
+++ b/src/coreload/arguments.cc
@@ -9,7 +9,8 @@ namespace coreload {
         app_argc(0),
         app_argv(nullptr),
         core_servicing(_X("")),
-        deps_path(_X("")) {
+        deps_path(_X(""))
+    {
 
     }
 }

--- a/src/coreload/common/pal.h
+++ b/src/coreload/common/pal.h
@@ -44,8 +44,13 @@ namespace coreload {
     namespace pal {
         
 #if defined(_WIN32)
+#ifdef COREHOST_MAKE_DLL
+#define SHARED_API extern "C" __declspec(dllexport)
+#else
+#define SHARED_API
+#endif
 
-#define STDMETHODCALLTYPE __stdcall
+        #define STDMETHODCALLTYPE __stdcall
 
         typedef wchar_t char_t;
         typedef std::wstring string_t;

--- a/src/coreload/common/pal.windows.cc
+++ b/src/coreload/common/pal.windows.cc
@@ -27,7 +27,6 @@ namespace coreload {
         }
 
         return false;
-
     }
 
     pal::string_t pal::to_lower(const pal::string_t& in)

--- a/src/coreload/coreclr.cc
+++ b/src/coreload/coreclr.cc
@@ -41,7 +41,8 @@ namespace coreload {
     static coreclr_initialize_fn coreclr_initialize = nullptr;
     static coreclr_execute_assembly_fn coreclr_execute_assembly = nullptr;
     static coreclr_create_delegate_fn coreclr_create_delegate = nullptr;
-    bool coreclr::bind(const pal::string_t& libcoreclr_path) {
+    bool coreclr::bind(const pal::string_t& libcoreclr_path)
+    {
         assert(g_coreclr == nullptr);
         pal::string_t coreclr_dll_path(libcoreclr_path);
         append_path(&coreclr_dll_path, LIBCORECLR_NAME);
@@ -58,7 +59,8 @@ namespace coreload {
         return true;
     }
 
-    void coreclr::unload() {
+    void coreclr::unload()
+    {
         assert(g_coreclr != nullptr && coreclr_initialize != nullptr);
 
         pal::unload_library(g_coreclr);
@@ -71,7 +73,8 @@ namespace coreload {
         const char** property_values,
         int property_count,
         host_handle_t* host_handle,
-        domain_id_t* domain_id) {
+        domain_id_t* domain_id)
+    {
         assert(g_coreclr != nullptr && coreclr_initialize != nullptr);
 
         return coreclr_initialize(
@@ -87,7 +90,8 @@ namespace coreload {
     pal::hresult_t coreclr::shutdown(
         host_handle_t host_handle,
         domain_id_t domain_id,
-        int* latchedExitCode) {
+        int* latchedExitCode)
+    {
         assert(g_coreclr != nullptr && coreclr_shutdown != nullptr);
 
         return coreclr_shutdown(host_handle, domain_id, latchedExitCode);
@@ -99,7 +103,8 @@ namespace coreload {
         int argc,
         const char** argv,
         const char* managed_assembly_path,
-        unsigned int* exit_code) {
+        unsigned int* exit_code)
+    {
         assert(g_coreclr != nullptr && coreclr_execute_assembly != nullptr);
 
         return coreclr_execute_assembly(

--- a/src/coreload/corehost.cc
+++ b/src/coreload/corehost.cc
@@ -19,6 +19,11 @@ namespace coreload {
         const char* type_name,
         const char* method_name,
         void** pfnDelegate) {
+        assert(assembly_name != nullptr);
+        assert(type_name != nullptr);
+        assert(method_name != nullptr);
+        assert(pfnDelegate != nullptr);
+
         auto hr = coreclr::create_delegate(
             corehost::m_handle,
             corehost::m_domain_id,

--- a/src/coreload/corehost.cc
+++ b/src/coreload/corehost.cc
@@ -10,7 +10,8 @@ namespace coreload {
     int corehost::initialize_clr(
         arguments_t& arguments,
         const host_startup_info_t& host_info,
-        host_mode_t mode) {
+        host_mode_t mode)
+    {
         return fx_muxer_t::initialize_clr(arguments, host_info, mode, corehost::m_domain_id, corehost::m_handle);
     }
 
@@ -18,7 +19,8 @@ namespace coreload {
         const char* assembly_name,
         const char* type_name,
         const char* method_name,
-        void** pfnDelegate) {
+        void** pfnDelegate)
+    {
         assert(assembly_name != nullptr);
         assert(type_name != nullptr);
         assert(method_name != nullptr);

--- a/src/coreload/deps_entry.cc
+++ b/src/coreload/deps_entry.cc
@@ -3,20 +3,24 @@
 #include "trace.h"
 
 namespace coreload {
-    bool deps_entry_t::to_path(const pal::string_t& base, bool look_in_base, pal::string_t* str) const {
+
+    bool deps_entry_t::to_path(const pal::string_t& base, bool look_in_base, pal::string_t* str) const
+    {
         pal::string_t& candidate = *str;
 
         candidate.clear();
 
         // Base directory must be present to obtain full path
-        if (base.empty()) {
+        if (base.empty())
+        {
             return false;
         }
 
         // Entry relative path contains '/' separator, sanitize it to use
         // platform separator. Perf: avoid extra copy if it matters.
         pal::string_t pal_relative_path = asset.relative_path;
-        if (_X('/') != DIR_SEPARATOR) {
+        if (_X('/') != DIR_SEPARATOR)
+        {
             replace_char(&pal_relative_path, _X('/'), DIR_SEPARATOR);
         }
 
@@ -30,11 +34,13 @@ namespace coreload {
 
         bool exists = pal::file_exists(candidate);
         const pal::char_t* query_type = look_in_base ? _X("Local") : _X("Relative");
-        if (!exists) {
+        if (!exists)
+        {
             trace::verbose(_X("    %s path query did not exist %s"), query_type, candidate.c_str());
             candidate.clear();
         }
-        else {
+        else
+        {
             trace::verbose(_X("    %s path query exists %s"), query_type, candidate.c_str());
         }
         return exists;
@@ -51,10 +57,13 @@ namespace coreload {
     // Returns:
     //    If the file exists in the path relative to the "base" directory.
     //
-    bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) const {
-        if (asset_type == asset_types::resources) {
+    bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str) const
+    {
+        if (asset_type == asset_types::resources)
+        {
             pal::string_t pal_relative_path = asset.relative_path;
-            if (_X('/') != DIR_SEPARATOR) {
+            if (_X('/') != DIR_SEPARATOR)
+            {
                 replace_char(&pal_relative_path, _X('/'), DIR_SEPARATOR);
             }
 
@@ -76,7 +85,6 @@ namespace coreload {
         }
         return to_path(base, true, str);
     }
-
     // -----------------------------------------------------------------------------
     // Given a "base" directory, yield the relative path of this file in the package
     // layout.
@@ -89,7 +97,8 @@ namespace coreload {
     // Returns:
     //    If the file exists in the path relative to the "base" directory.
     //
-    bool deps_entry_t::to_rel_path(const pal::string_t& base, pal::string_t* str) const {
+    bool deps_entry_t::to_rel_path(const pal::string_t& base, pal::string_t* str) const
+    {
         return to_path(base, false, str);
     }
 
@@ -105,21 +114,25 @@ namespace coreload {
     // Returns:
     //    If the file exists in the path relative to the "base" directory.
     //
-    bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str) const {
+    bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str) const
+    {
         str->clear();
 
         // Base directory must be present to obtain full path
-        if (base.empty()) {
+        if (base.empty())
+        {
             return false;
         }
 
         pal::string_t new_base = base;
 
-        if (library_path.empty()) {
+        if (library_path.empty())
+        {
             append_path(&new_base, library_name.c_str());
             append_path(&new_base, library_version.c_str());
         }
-        else {
+        else
+        {
             append_path(&new_base, library_path.c_str());
         }
 

--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -1,5 +1,26 @@
 #include "coreload.h"
 
+int ValidateArgument(
+    const pal::char_t* argument,
+    size_t max_size) {
+    if (argument != nullptr && pal::strncmp(argument, _X(""), max_size) != 0) {
+        const size_t string_length = pal::strlen(argument);
+        if (string_length >= max_size) {
+            return StatusCode::InvalidArgFailure;
+        }
+    }
+    else {
+        return StatusCode::InvalidArgFailure;
+    }
+    return StatusCode::Success;
+}
+
+bool inline IsValidCoreHostArgument(
+    const pal::char_t* argument,
+    size_t max_size) {
+    return ValidateArgument(argument, max_size) == StatusCode::Success;
+}
+
 // Start the .NET Core runtime in the current application
 int StartCoreCLRInternal(
     const pal::char_t*  assembly_path,
@@ -23,12 +44,18 @@ int StartCoreCLRInternal(
 }
 
 // Host the .NET Core runtime in the current application
-DllApi int StartCoreCLR(const core_host_arguments* arguments) {
+SHARED_API int StartCoreCLR(const core_host_arguments* arguments) {
+    if (arguments == nullptr 
+        || !IsValidCoreHostArgument(arguments->assembly_file_path, MAX_PATH)
+        || !IsValidCoreHostArgument(arguments->core_root_path, MAX_PATH))
+    {
+        return StatusCode::InvalidArgFailure;
+    }
     return StartCoreCLRInternal(arguments->assembly_file_path, arguments->core_root_path, arguments->verbose);
 }
 
 // Create a native function delegate for a function inside a .NET assembly
-DllApi int CreateAssemblyDelegate(
+SHARED_API int CreateAssemblyDelegate(
     const char* assembly_name,
     const char* type_name,
     const char* method_name,
@@ -75,7 +102,15 @@ int ExecuteAssemblyClassFunction(
 }
 
 // Execute a function located in a .NET assembly by creating a native delegate
-DllApi int ExecuteAssemblyFunction(const assembly_function_call* arguments) {
+SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments) {
+    if (arguments == nullptr 
+        || !IsValidCoreHostArgument(arguments->assembly_name, max_function_name_size)
+        || !IsValidCoreHostArgument(arguments->class_name, max_function_name_size)
+        || !IsValidCoreHostArgument(arguments->function_name, max_function_name_size))
+    {
+        return StatusCode::InvalidArgFailure;
+    }
+
     std::vector<char> assembly_name, class_name, function_name;
     pal::pal_clrstring(arguments->assembly_name, &assembly_name);
     pal::pal_clrstring(arguments->class_name, &class_name);
@@ -85,7 +120,7 @@ DllApi int ExecuteAssemblyFunction(const assembly_function_call* arguments) {
 }
 
 // Shutdown the .NET Core runtime
-DllApi int UnloadRuntime() {
+SHARED_API int UnloadRuntime() {
     return corehost::unload_runtime();
 }
 

--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -2,14 +2,18 @@
 
 int ValidateArgument(
     const pal::char_t* argument,
-    size_t max_size) {
-    if (argument != nullptr && pal::strncmp(argument, _X(""), max_size) != 0) {
+    size_t max_size)
+{
+    if (argument != nullptr && pal::strncmp(argument, _X(""), max_size) != 0)
+    {
         const size_t string_length = pal::strlen(argument);
-        if (string_length >= max_size) {
+        if (string_length >= max_size)
+        {
             return StatusCode::InvalidArgFailure;
         }
     }
-    else {
+    else
+    {
         return StatusCode::InvalidArgFailure;
     }
     return StatusCode::Success;
@@ -17,7 +21,8 @@ int ValidateArgument(
 
 bool inline IsValidCoreHostArgument(
     const pal::char_t* argument,
-    size_t max_size) {
+    size_t max_size)
+{
     return ValidateArgument(argument, max_size) == StatusCode::Success;
 }
 
@@ -25,8 +30,10 @@ bool inline IsValidCoreHostArgument(
 int StartCoreCLRInternal(
     const pal::char_t*  assembly_path,
     const pal::char_t*  core_root,
-    const unsigned char verbose_log) {
-    if (verbose_log) {
+    const unsigned char verbose_log)
+{
+    if (verbose_log)
+    {
         trace::enable();
     }
     host_startup_info_t startup_info;
@@ -44,13 +51,16 @@ int StartCoreCLRInternal(
 }
 
 // Host the .NET Core runtime in the current application
-SHARED_API int StartCoreCLR(const core_host_arguments* arguments) {
+SHARED_API int StartCoreCLR(
+    const core_host_arguments* arguments)
+{
     if (arguments == nullptr 
         || !IsValidCoreHostArgument(arguments->assembly_file_path, MAX_PATH)
         || !IsValidCoreHostArgument(arguments->core_root_path, MAX_PATH))
     {
         return StatusCode::InvalidArgFailure;
     }
+
     return StartCoreCLRInternal(arguments->assembly_file_path, arguments->core_root_path, arguments->verbose);
 }
 
@@ -59,7 +69,8 @@ SHARED_API int CreateAssemblyDelegate(
     const char* assembly_name,
     const char* type_name,
     const char* method_name,
-    void**      pfnDelegate) {
+    void**      pfnDelegate)
+{
     return corehost::create_delegate(
         assembly_name,
         type_name,
@@ -73,36 +84,42 @@ int ExecuteAssemblyClassFunction(
     const char* assembly,
     const char* type,
     const char* entry,
-    const unsigned char* arguments) {
+    const unsigned char* arguments)
+{
     int exit_code = StatusCode::HostApiFailed;
     typedef void (STDMETHODCALLTYPE load_plugin_fn)(const void *load_plugin_arguments);
     load_plugin_fn* load_plugin_delegate = nullptr;
 
-    if (SUCCEEDED(exit_code = CreateAssemblyDelegate(assembly, type, entry, reinterpret_cast<PVOID*>(&load_plugin_delegate)))) {
+    if (SUCCEEDED(exit_code = CreateAssemblyDelegate(assembly, type, entry, reinterpret_cast<PVOID*>(&load_plugin_delegate))))
+    {
         remote_entry_info entry_info = { 0 };
         entry_info.host_process_id = GetCurrentProcessId();
 
         const auto remote_arguments = reinterpret_cast<const core_load_arguments*>(arguments);
-        if (remote_arguments != nullptr) {
+        if (remote_arguments != nullptr)
+        {
             // Construct and pass the remote user parameters to the .NET delegate
             entry_info.arguments.user_data_size = remote_arguments->user_data_size;
             entry_info.arguments.user_data = remote_arguments->user_data_size ? remote_arguments->user_data : nullptr;
 
             load_plugin_delegate(&entry_info);
         }
-        else {
+        else
+        {
             // No arguments were supplied to pass to the delegate function
             load_plugin_delegate(nullptr);
         }
     }
-    else {
+    else
+    {
         exit_code = StatusCode::InvalidArgFailure;
     }
     return exit_code;
 }
 
 // Execute a function located in a .NET assembly by creating a native delegate
-SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments) {
+SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments) 
+{
     if (arguments == nullptr 
         || !IsValidCoreHostArgument(arguments->assembly_name, max_function_name_size)
         || !IsValidCoreHostArgument(arguments->class_name, max_function_name_size)
@@ -120,14 +137,16 @@ SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments) 
 }
 
 // Shutdown the .NET Core runtime
-SHARED_API int UnloadRuntime() {
+SHARED_API int UnloadRuntime()
+{
     return corehost::unload_runtime();
 }
 
 BOOL APIENTRY DllMain(
     HMODULE hModule,
     DWORD   ul_reason_for_call,
-    LPVOID  lpReserved) {
+    LPVOID  lpReserved)
+{
     switch (ul_reason_for_call)
     {
         case DLL_PROCESS_ATTACH:

--- a/src/coreload/dll/coreload.h
+++ b/src/coreload/dll/coreload.h
@@ -57,14 +57,10 @@ SHARED_API int CreateAssemblyDelegate(
 );
 
 // Execute a function located in a .NET assembly by creating a native delegate
-SHARED_API int ExecuteAssemblyFunction(
-    const assembly_function_call* arguments
-);
+SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments);
 
 // Host the .NET Core runtime in the current application
-SHARED_API int StartCoreCLR(
-    const core_host_arguments* arguments
-);
+SHARED_API int StartCoreCLR(const core_host_arguments* arguments);
 
 // Stop the .NET Core host in the current application
 SHARED_API int UnloadRuntime();

--- a/src/coreload/dll/coreload.h
+++ b/src/coreload/dll/coreload.h
@@ -7,16 +7,6 @@
 #include "corehost.h"
 #include "status_code.h"
 
-// Function export macro
-#ifdef _USRDLL  
-#define DllExport    __declspec(dllexport)
-#else
-#define DllExport    __declspec(dllimport)
-#endif
-
-// Export functions with their plain name
-#define DllApi extern "C" DllExport
-
 // The max length of a function to be executed in a .NET class
 #define max_function_name_size                  256
 
@@ -59,9 +49,7 @@ struct remote_entry_info
 // DLL exports used for starting, executing in, and stopping the .NET Core runtime
 
 // Create a native function delegate for a function inside a .NET assembly
-DllApi
-int
-CreateAssemblyDelegate(
+SHARED_API int CreateAssemblyDelegate(
     const char* assembly_name,
     const char* type_name,
     const char* method_name,
@@ -69,22 +57,16 @@ CreateAssemblyDelegate(
 );
 
 // Execute a function located in a .NET assembly by creating a native delegate
-DllApi
-int
-ExecuteAssemblyFunction(
+SHARED_API int ExecuteAssemblyFunction(
     const assembly_function_call* arguments
 );
 
 // Host the .NET Core runtime in the current application
-DllApi
-int
-StartCoreCLR(
+SHARED_API int StartCoreCLR(
     const core_host_arguments* arguments
 );
 
 // Stop the .NET Core host in the current application
-DllApi
-int
-UnloadRuntime();
+SHARED_API int UnloadRuntime();
 
 #endif // CORELOAD_DLL_H

--- a/src/coreload/framework_info.cc
+++ b/src/coreload/framework_info.cc
@@ -107,5 +107,4 @@ namespace coreload {
 
         return framework_infos.size() > 0;
     }
-
 }

--- a/src/coreload/fx_definition.cc
+++ b/src/coreload/fx_definition.cc
@@ -12,9 +12,11 @@ namespace coreload {
         : m_name(name)
         , m_dir(dir)
         , m_requested_version(requested_version)
-        , m_found_version(found_version) {
+        , m_found_version(found_version)
+    {
 
     }
+
     void fx_definition_t::parse_runtime_config(
         const pal::string_t& path,
         const pal::string_t& dev_path,

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -17,13 +17,13 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
     PCSTR method_name_load = "Load";
 
     PCWSTR dotnet_sdk_root
-        = L"%programfiles%\\dotnet\\sdk\\2.2.100";
+        = L"%programfiles%\\dotnet\\sdk\\2.2.102";
 
     WCHAR dotnet_root[MAX_PATH];
     ::ExpandEnvironmentStringsW(dotnet_sdk_root, dotnet_root, MAX_PATH);
 
     pal::string_t library_path = dotnet_assembly_name;
-    EXPECT_TRUE(pal::realpath(&library_path));
+    ASSERT_TRUE(pal::realpath(&library_path));
 
     core_host_arguments host_arguments = { 0 };
     wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, library_path.c_str());
@@ -31,7 +31,7 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
 
     auto error = StartCoreCLR(&host_arguments);
  
-    EXPECT_EQ(NO_ERROR, error);
+    ASSERT_EQ(NO_ERROR, error);
     typedef int (STDMETHODCALLTYPE calculator_method_fn)(const int a, const int b);
 
     // Test the 'int Add(int a, int b) => a + b;' method
@@ -42,7 +42,9 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
         method_name_add,
         reinterpret_cast<void**>(&calculator_delegate)
     );
-    EXPECT_EQ(NO_ERROR, error);
+    ASSERT_EQ(NO_ERROR, error);
+    ASSERT_NE(nullptr, calculator_delegate);
+
     const int integer_a = 1;
     const int integer_b = 2;
     const int integer_add_result = integer_a + integer_b;
@@ -56,7 +58,9 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
         method_name_subtract,
         reinterpret_cast<void**>(&calculator_delegate)
     );
-    EXPECT_EQ(NO_ERROR, error);
+    ASSERT_EQ(NO_ERROR, error);
+    ASSERT_NE(nullptr, calculator_delegate);
+
     const int integer_subtract_result = integer_b - integer_a;
 
     EXPECT_EQ(integer_subtract_result, calculator_delegate(integer_a, integer_b));
@@ -68,7 +72,9 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
         method_name_multiply,
         reinterpret_cast<void**>(&calculator_delegate)
     );
-    EXPECT_EQ(NO_ERROR, error);
+    ASSERT_EQ(NO_ERROR, error);
+    ASSERT_NE(nullptr, calculator_delegate);
+
     const int integer_multiply_result = integer_a * integer_b;
 
     EXPECT_EQ(integer_multiply_result, calculator_delegate(integer_a, integer_b));
@@ -80,7 +86,8 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
         method_name_divide,
         reinterpret_cast<void**>(&calculator_delegate)
     );
-    EXPECT_EQ(NO_ERROR, error);
+    ASSERT_EQ(NO_ERROR, error);
+    ASSERT_NE(nullptr, calculator_delegate);
     const int integer_divide_result = integer_a / integer_b;
 
     EXPECT_EQ(integer_divide_result, calculator_delegate(integer_a, integer_b));
@@ -94,7 +101,9 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
             method_name_load,
             reinterpret_cast<void**>(&fn_method_load_delegate));
 
-    EXPECT_EQ(NOERROR, error);
+    ASSERT_EQ(NOERROR, error);
+    ASSERT_NE(nullptr, fn_method_load_delegate);
+
     assembly_function_call assembly_function_call = { 0 };
 
     pal::string_t assembly_name_wide;

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -123,3 +123,101 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
     // Unload the AppDomain and stop the host
     EXPECT_EQ(NOERROR, UnloadRuntime());
 }
+TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName) {
+    assembly_function_call assembly_function_call = { 0 };
+
+    pal::string_t assembly_name_wide;
+    pal::string_t type_name_wide;
+    pal::string_t method_name_wide;
+
+    const auto empty_string = _X("");
+
+    wcscpy_s(assembly_function_call.assembly_name, max_function_name_size, empty_string);
+    wcscpy_s(assembly_function_call.class_name, max_function_name_size, _X("ClassName"));
+    wcscpy_s(assembly_function_call.function_name, max_function_name_size, _X("MethodName"));
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+}
+
+TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassName) {
+    assembly_function_call assembly_function_call = { 0 };
+
+    pal::string_t assembly_name_wide;
+    pal::string_t type_name_wide;
+    pal::string_t method_name_wide;
+
+    const auto empty_string = _X("");
+
+    wcscpy_s(assembly_function_call.assembly_name, max_function_name_size, _X("AssemblyName"));
+    wcscpy_s(assembly_function_call.class_name, max_function_name_size, empty_string);
+    wcscpy_s(assembly_function_call.function_name, max_function_name_size, _X("MethodName"));
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+}
+
+TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName) {
+    assembly_function_call assembly_function_call = { 0 };
+
+    pal::string_t assembly_name_wide;
+    pal::string_t type_name_wide;
+    pal::string_t method_name_wide;
+
+    const auto empty_string = _X("");
+
+    wcscpy_s(assembly_function_call.assembly_name, max_function_name_size, _X("AssemblyName"));
+    wcscpy_s(assembly_function_call.class_name, max_function_name_size, _X("ClassName"));
+    wcscpy_s(assembly_function_call.function_name, max_function_name_size, empty_string);
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+}
+TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithEmptyArguments) {
+    assembly_function_call assembly_function_call = { 0 };
+
+    pal::string_t assembly_name_wide;
+    pal::string_t type_name_wide;
+    pal::string_t method_name_wide;
+
+    const auto empty_string = _X("");
+
+    wcscpy_s(assembly_function_call.assembly_name, max_function_name_size, empty_string);
+    wcscpy_s(assembly_function_call.class_name, max_function_name_size, empty_string);
+    wcscpy_s(assembly_function_call.function_name, max_function_name_size, empty_string);
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+}
+TEST(TestLibraryExports, TestStartCoreCLRWithEmptyArguments) {
+    core_host_arguments host_arguments = { 0 };
+
+    const auto empty_string = _X("");
+    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
+    wcscpy_s(host_arguments.core_root_path, MAX_PATH, empty_string);
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+}
+
+TEST(TestLibraryExports, TestStartCoreCLRWithEmptyAssemblyPath) {
+    core_host_arguments host_arguments = { 0 };
+
+    const auto empty_string = _X("");
+    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
+    wcscpy_s(host_arguments.core_root_path, MAX_PATH, _X("C:\\"));
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+}
+
+TEST(TestLibraryExports, TestStartCoreCLRWithEmptyCoreRootPath) {
+    core_host_arguments host_arguments = { 0 };
+
+    const auto empty_string = _X("");
+    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, _X("C:\\"));
+    wcscpy_s(host_arguments.core_root_path, MAX_PATH, empty_string);
+
+    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+}
+TEST(TestLibraryExports, TestExecuteAssemblyFunctionArgumentsNULL) {
+    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(nullptr));
+}
+
+TEST(TestLibraryExports, TestStartCoreCLRArgumentsNull) {
+    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(nullptr));
+}

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "coreload.h"
-
-TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
+TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly) {
     // Assembly file name for getting base library path 
     // that is given to the .NET Core host when starting it
     PCWSTR dotnet_assembly_name = L"Calculator.dll";
@@ -20,7 +19,7 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
         = L"%programfiles%\\dotnet\\sdk\\2.2.102";
 
     WCHAR dotnet_root[MAX_PATH];
-    ::ExpandEnvironmentStringsW(dotnet_sdk_root, dotnet_root, MAX_PATH);
+    ExpandEnvironmentStringsW(dotnet_sdk_root, dotnet_root, MAX_PATH);
 
     pal::string_t library_path = dotnet_assembly_name;
     ASSERT_TRUE(pal::realpath(&library_path));
@@ -123,7 +122,7 @@ TEST(TestExecuteDotnetAssembly, TestExecuteDotnetAssemblyName) {
     // Unload the AppDomain and stop the host
     EXPECT_EQ(NOERROR, UnloadRuntime());
 }
-TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName) {
+TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName) {
     assembly_function_call assembly_function_call = { 0 };
 
     pal::string_t assembly_name_wide;
@@ -139,7 +138,7 @@ TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName) {
     EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
-TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassName) {
+TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassName) {
     assembly_function_call assembly_function_call = { 0 };
 
     pal::string_t assembly_name_wide;
@@ -155,7 +154,7 @@ TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassName) {
     EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
-TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName) {
+TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName) {
     assembly_function_call assembly_function_call = { 0 };
 
     pal::string_t assembly_name_wide;
@@ -170,7 +169,7 @@ TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName)
 
     EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
-TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithEmptyArguments) {
+TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithEmptyArguments) {
     assembly_function_call assembly_function_call = { 0 };
 
     pal::string_t assembly_name_wide;
@@ -185,7 +184,7 @@ TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithEmptyArguments) {
 
     EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
-TEST(TestLibraryExports, TestStartCoreCLRWithEmptyArguments) {
+TEST(LibraryExportsTest, TestStartCoreCLRWithEmptyArguments) {
     core_host_arguments host_arguments = { 0 };
 
     const auto empty_string = _X("");


### PR DESCRIPTION
* Validate the arguments passed to the DLL exports to provide feedback with errors by returning an invalid argument error code.
* Add more tests for the DLL export arguments.
* Make code style more consistent across the projects.
* Update export DLL definition to use the PAL shared_api definition.