### PR TITLE
Update compile definitions for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 include_directories(${CORELOAD_INSTALL_INCLUDE_DIR})
 
 project(coreload_dll)
-add_definitions(-DCOREHOST_MAKE_DLL=1)
 if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
     add_definitions(-D_TARGET_X86_=1 -DCORELOAD_BITS=32)
     set(CORELOAD_DLL_NAME "coreload32")

--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@
 
 A library for hosting .NET Core with [CoreHook](https://github.com/unknownv2/CoreHook) in an unmanaged application on Windows.
 
-## Build status
+# Build status
 
 | Build server | Platform    | Build status                             |
 | ------------ | ----------- | ---------------------------------------- |
 | AppVeyor     | Windows     | [![Build status](https://ci.appveyor.com/api/projects/status/7c0lfec5c7tlvo2a/branch/master?style=flat-square)](https://ci.appveyor.com/project/unknownv2/corehook-host/branch/master) |
 
-## Binary Releases 
+# Binary Releases 
  You download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Host/releases) or you can build the binaries from source.
  
- ## Usage
- 
+ # Usage
+
  For `x86, x64`, extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the build output directory of your program.
  
  For `ARM, ARM64`,  extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the output directory of your published program, created either from using the [Publishing Script](https://github.com/unknownv2/CoreHook#publishing-script) or the `dotnet publish` command.
 
-## Building
+# Building
 
 ## Windows (x86, x64, ARM, ARM64)
 
@@ -62,7 +62,7 @@ You can compile the .NET class [`Calculator.cs`](tests/dotnet/Calculator.cs), wh
 csc -target:library Calculator.cs
 ```
 
-## Credits
+# Credits
 
 The `coreload` project is based on the [core-setup](https://github.com/dotnet/core-setup/) host which supports parsing the `.deps.json` and `runtimeconfig.json` application configuration files.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ A library for hosting .NET Core with [CoreHook](https://github.com/unknownv2/Cor
 | ------------ | ----------- | ---------------------------------------- |
 | AppVeyor     | Windows     | [![Build status](https://ci.appveyor.com/api/projects/status/7c0lfec5c7tlvo2a/branch/master?style=flat-square)](https://ci.appveyor.com/project/unknownv2/corehook-host/branch/master) |
 
+## Binary Releases 
+ You download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Host/releases) or you can build the binaries from source.
+ 
+ ## Usage
+ 
+ For `x86, x64`, extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the build output directory of your program.
+ 
+ For `ARM, ARM64`,  extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the output directory of your published program, created either from using the [Publishing Script](https://github.com/unknownv2/CoreHook#publishing-script) or the `dotnet publish` command.
+
 ## Building
 
 ## Windows (x86, x64, ARM, ARM64)
@@ -52,13 +61,6 @@ You can compile the .NET class [`Calculator.cs`](tests/dotnet/Calculator.cs), wh
 ```
 csc -target:library Calculator.cs
 ```
-
-### Binary Releases 
- You can also download the pre-built Windows binaries [here](https://github.com/unknownv2/CoreHook.Host/releases).
- 
- For `x86, x64`, extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the build output directory of your program.
- 
- For `ARM, ARM64`,  extract the zip corresponding to your target architecture, then place the `coreload32.dll` or `coreload64.dll` in the output directory of your published program, created either from using the [Publishing Script](https://github.com/unknownv2/CoreHook#publishing-script) or the `dotnet publish` command.
 
 ## Credits
 

--- a/src/coreload/dll/CMakeLists.txt
+++ b/src/coreload/dll/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CORELOAD_DLL_SOURCES
     )
 
 add_library(coreload_dll SHARED ${CORELOAD_DLL_SOURCES})
-target_compile_definitions(coreload_dll PRIVATE _USRDLL=1)
+target_compile_definitions(coreload_dll PRIVATE COREHOST_MAKE_DLL=1)
 
 target_link_libraries(coreload_dll coreload)
 set_target_properties(coreload_dll PROPERTIES OUTPUT_NAME ${CORELOAD_DLL_NAME})

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "coreload.h"
-TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly) {
+
+TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly)
+{
     // Assembly file name for getting base library path 
     // that is given to the .NET Core host when starting it
     PCWSTR dotnet_assembly_name = L"Calculator.dll";
@@ -25,9 +27,15 @@ TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly) {
     ASSERT_TRUE(pal::realpath(&library_path));
 
     core_host_arguments host_arguments = { 0 };
+    // The path to the assembly being loaded by CoreCLR.
     wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, library_path.c_str());
+    // The path that should contain the runtime configuration or dependencies for the assembly
     wcscpy_s(host_arguments.core_root_path, MAX_PATH, dotnet_root);
 
+    // This will initialize CoreCLR in the current application,
+    // which allows us to load assemblies from the paths defined by the
+    // runtime configuration or from the base application path of the 
+    // test assembly library Calculator.dll.
     auto error = StartCoreCLR(&host_arguments);
  
     ASSERT_EQ(NO_ERROR, error);
@@ -122,6 +130,7 @@ TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly) {
     // Unload the AppDomain and stop the host
     EXPECT_EQ(NOERROR, UnloadRuntime());
 }
+
 TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName) {
     assembly_function_call assembly_function_call = { 0 };
 


### PR DESCRIPTION
* Update CMake build script to add the COREHOST_MAKE_DLL definition to the DLL only since we aren't building the tests with CMake yet.

* Move the binary releases section to the top of the README so people see that first.