### PR TITLE
Update headers and namespace code style

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ csc -target:library Calculator.cs
 
 # Credits
 
-The `coreload` project is based on the [core-setup](https://github.com/dotnet/core-setup/) host which supports parsing the `.deps.json` and `runtimeconfig.json` application configuration files.
+The `coreload` project is based on the [core-setup](https://github.com/dotnet/core-setup/) host which supports parsing the `.deps.json` and `runtimeconfig.json` application configuration files. Most of the code for this library is borrowed from [the corehost source](https://github.com/dotnet/core-setup/tree/master/src/corehost).
 
 ## References
 * [.NET Core Hosting Sample](https://github.com/dotnet/samples/tree/master/core/hosting)

--- a/src/coreload/arguments.cc
+++ b/src/coreload/arguments.cc
@@ -1,6 +1,7 @@
 #include "arguments.h"
 
-namespace coreload {
+namespace coreload
+{
     arguments_t::arguments_t() :
         managed_application(_X("")),
         host_path(_X("")),
@@ -12,4 +13,4 @@ namespace coreload {
     {
 
     }
-}
+} // namespace coreload

--- a/src/coreload/arguments.h
+++ b/src/coreload/arguments.h
@@ -1,5 +1,5 @@
-#ifndef ARGUMENTS_H
-#define ARGUMENTS_H
+#ifndef ARGUMENTS_H_
+#define ARGUMENTS_H_
 
 #include "utils.h"
 #include "pal.h"
@@ -103,4 +103,4 @@ namespace coreload {
         arguments_t();
     };
 }
-#endif // ARGUMENTS_H
+#endif // ARGUMENTS_H_

--- a/src/coreload/common/longfile.cc
+++ b/src/coreload/common/longfile.cc
@@ -1,8 +1,8 @@
-
 #include "pal.h"
 #include "longfile.h"
 
-namespace coreload {
+namespace coreload 
+{
     const pal::char_t LongFile::DirectorySeparatorChar = _X('\\');
     const pal::char_t LongFile::AltDirectorySeparatorChar = _X('/');
     const pal::char_t LongFile::VolumeSeparatorChar = _X(':');
@@ -136,5 +136,4 @@ namespace coreload {
     {
         return c == DirectorySeparatorChar || c == AltDirectorySeparatorChar;
     }
-
-}
+} // namespace coreload

--- a/src/coreload/common/longfile.h
+++ b/src/coreload/common/longfile.h
@@ -1,11 +1,12 @@
-
-#ifndef _LONG_FILE_SUPPORT
-#define _LONG_FILE_SUPPORT
+#ifndef LONG_FILE_SUPPORT_
+#define LONG_FILE_SUPPORT_
 
 #include "pal.h"
 
-namespace coreload {
-    class LongFile {
+namespace coreload
+{
+    class LongFile
+    {
     public:
         static const pal::string_t ExtendedPrefix;
         static const pal::string_t DevicePathPrefix;
@@ -24,6 +25,7 @@ namespace coreload {
         static bool IsNormalized(const pal::string_t& path);
         static bool ShouldNormalize(const pal::string_t& path);
     };
-}
 
-#endif // _LONG_FILE_SUPPORT
+} // namespace coreload
+
+#endif // LONG_FILE_SUPPORT_

--- a/src/coreload/common/pal.h
+++ b/src/coreload/common/pal.h
@@ -1,5 +1,5 @@
-#ifndef PAL_H
-#define PAL_H
+#ifndef PAL_H_
+#define PAL_H_
 
 #include <string>
 #include <fstream>
@@ -39,8 +39,10 @@
 #define LIBHOSTPOLICY_FILENAME (LIB_PREFIX _X("hostpolicy"))
 #define LIBHOSTPOLICY_NAME MAKE_LIBNAME("hostpolicy")
 
-namespace coreload {
-    namespace pal {        
+namespace coreload
+{
+    namespace pal
+    {
 #if defined(_WIN32)
 #ifdef COREHOST_MAKE_DLL
 #define SHARED_API extern "C" __declspec(dllexport)
@@ -136,7 +138,9 @@ namespace coreload {
         bool is_running_in_wow64();
 
         bool are_paths_equal_with_normalized_casing(const string_t& path1, const string_t& path2);
-    }
-}
 
-#endif // PAL_H
+    } // namespace pal
+
+} // namespace coreload
+
+#endif // PAL_H_

--- a/src/coreload/common/pal.windows.cc
+++ b/src/coreload/common/pal.windows.cc
@@ -7,7 +7,8 @@
 #include <codecvt>
 #include <ShlObj.h>
 
-namespace coreload {
+namespace coreload
+{
     bool GetModuleFileNameWrapper(HMODULE hModule, pal::string_t* recv)
     {
         pal::string_t path;
@@ -533,4 +534,4 @@ namespace coreload {
         // On Windows, paths are case-insensitive
         return (strcasecmp(path1.c_str(), path2.c_str()) == 0);
     }
-}
+} // namespace coreload

--- a/src/coreload/common/trace.cc
+++ b/src/coreload/common/trace.cc
@@ -1,10 +1,8 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include "trace.h"
 #include <mutex>
 
-namespace coreload {
+namespace coreload
+{
     // g_trace_verbosity is used to encode COREHOST_TRACE and COREHOST_TRACE_VERBOSITY to selectively control output of
     //    trace::warn(), trace::info(), and trace::verbose()
     //  COREHOST_TRACE=0 COREHOST_TRACE_VERBOSITY=N/A        implies g_trace_verbosity = 0.  // Trace "disabled". error() messages will be produced.
@@ -206,4 +204,4 @@ namespace coreload {
         // No need for locking since g_error_writer is thread local.
         return g_error_writer;
     }
-}
+} // namespace coreload

--- a/src/coreload/common/trace.h
+++ b/src/coreload/common/trace.h
@@ -1,12 +1,10 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-#ifndef TRACE_H
-#define TRACE_H
+#ifndef TRACE_H_
+#define TRACE_H_
 
 #include "pal.h"
 
-namespace coreload {
+namespace coreload
+{
     namespace trace
     {
         void setup();
@@ -32,5 +30,7 @@ namespace coreload {
         // Returns the currently set callback for error writing
         error_writer_fn get_error_writer();
     };
-}
-#endif // TRACE_H
+
+} // namespace coreload
+
+#endif // TRACE_H_

--- a/src/coreload/common/utils.cc
+++ b/src/coreload/common/utils.cc
@@ -1,10 +1,8 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include "utils.h"
 #include "trace.h"
 
-namespace coreload {
+namespace coreload
+{
     bool library_exists_in_dir(const pal::string_t& lib_dir, const pal::string_t& lib_name, pal::string_t* p_lib_path)
     {
         pal::string_t lib_path = lib_dir;
@@ -382,5 +380,4 @@ namespace coreload {
 
         return pal::string_t(_X("DOTNET_ROOT"));
     }
-
-}
+} // namespace coreload

--- a/src/coreload/common/utils.h
+++ b/src/coreload/common/utils.h
@@ -1,11 +1,10 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-#ifndef UTILS_H
-#define UTILS_H
+#ifndef UTILS_H_
+#define UTILS_H_
 
 #include "pal.h"
-namespace coreload {
+
+namespace coreload
+{
     struct host_option
     {
         pal::string_t option;
@@ -51,5 +50,6 @@ namespace coreload {
     bool try_stou(const pal::string_t& str, unsigned* num);
     pal::string_t get_dotnet_root_env_var_name();
 
-}
-#endif
+} // namespace coreload
+
+#endif // UTILS_H_

--- a/src/coreload/coreclr.cc
+++ b/src/coreload/coreclr.cc
@@ -2,7 +2,8 @@
 #include "coreclr.h"
 #include "utils.h"
 
-namespace coreload {
+namespace coreload
+{
     static pal::dll_t g_coreclr = nullptr;
 
     // Prototype of the coreclr_initialize function from coreclr.dll
@@ -129,4 +130,4 @@ namespace coreload {
 
         return coreclr_create_delegate(host_handle, domain_id, assembly_name, type_name, method_name, delegate);
     }
-}
+} // namespace coreload

--- a/src/coreload/coreclr.h
+++ b/src/coreload/coreclr.h
@@ -1,9 +1,12 @@
-#ifndef CLR_H
-#define CLR_H
+#ifndef CLR_H_
+#define CLR_H_
+
 #include "pal.h"
 
-namespace coreload {    
-    namespace coreclr {
+namespace coreload
+{
+    namespace coreclr
+    {
         typedef void* host_handle_t;
         typedef unsigned int domain_id_t;
 
@@ -40,6 +43,9 @@ namespace coreload {
             const char* type_name,
             const char* method_name,
             void** delegate);
-    }
-}
-#endif // CLR_H
+
+    } // namespace coreclr
+
+} // namespace coreload
+
+#endif // CLR_H_

--- a/src/coreload/corehost.cc
+++ b/src/coreload/corehost.cc
@@ -3,7 +3,8 @@
 #include "fx_muxer.h"
 #include "corehost.h"
 
-namespace coreload {
+namespace coreload
+{
     coreclr::domain_id_t corehost::m_domain_id = 0;
     coreclr::host_handle_t corehost::m_handle = nullptr;
 
@@ -55,4 +56,4 @@ namespace coreload {
         coreclr::unload();
         return exit_code;
     }
-}
+} // namespace coreload

--- a/src/coreload/corehost.h
+++ b/src/coreload/corehost.h
@@ -1,12 +1,13 @@
-#pragma once
-#ifndef COREHOST_H
-#define COREHOST_H
+#ifndef COREHOST_H_
+#define COREHOST_H_
 
 #include "libhost.h"
 #include "coreclr.h"
 
-namespace coreload {
-    class corehost {
+namespace coreload
+{
+    class corehost
+    {
     public:
         static coreclr::host_handle_t m_handle;
         static coreclr::domain_id_t m_domain_id;
@@ -23,6 +24,7 @@ namespace coreload {
 
         static int unload_runtime();
     };
-}
 
-#endif // COREHOST_H
+} // namespace coreload
+
+#endif // COREHOST_H_

--- a/src/coreload/deps_entry.cc
+++ b/src/coreload/deps_entry.cc
@@ -2,7 +2,8 @@
 #include "utils.h"
 #include "trace.h"
 
-namespace coreload {
+namespace coreload
+{
     bool deps_entry_t::to_path(const pal::string_t& base, bool look_in_base, pal::string_t* str) const
     {
         pal::string_t& candidate = *str;
@@ -137,4 +138,4 @@ namespace coreload {
 
         return to_rel_path(new_base, str);
     }
-}
+} // namespace coreload

--- a/src/coreload/deps_entry.h
+++ b/src/coreload/deps_entry.h
@@ -1,5 +1,5 @@
-#ifndef DEPS_ENTRY_H
-#define DEPS_ENTRY_H
+#ifndef DEPS_ENTRY_H_
+#define DEPS_ENTRY_H_
 
 #include <iostream>
 #include <array>
@@ -7,7 +7,8 @@
 #include "pal.h"
 #include "version.h"
 
-namespace coreload {
+namespace coreload
+{
     struct deps_asset_t
     {
         deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t(), version_t()) { }
@@ -60,6 +61,7 @@ namespace coreload {
         // Given a "base" dir, yield the relative path with package name, version in the package layout.
         bool to_full_path(const pal::string_t& root, pal::string_t* str) const;
     };
-}
 
-#endif // DEPS_ENTRY_H
+} // namespace coreload
+
+#endif // DEPS_ENTRY_H_

--- a/src/coreload/deps_format.cc
+++ b/src/coreload/deps_format.cc
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include "deps_entry.h"
 #include "deps_format.h"
 #include "utils.h"
@@ -10,7 +7,8 @@
 #include <cassert>
 #include <functional>
 
-namespace coreload {
+namespace coreload
+{
     const std::array<const pal::char_t*, deps_entry_t::asset_types::count> deps_entry_t::s_known_asset_types = {
         _X("runtime"), _X("resources"), _X("native")
     };
@@ -485,5 +483,4 @@ namespace coreload {
             return false;
         }
     }
-
-}
+} // namespace coreload

--- a/src/coreload/deps_format.h
+++ b/src/coreload/deps_format.h
@@ -114,5 +114,7 @@ namespace coreload
 
         pal::string_t m_deps_file;
     };
-}
+
+} // namespace coreload
+
 #endif // DEPS_FORMAT_H_

--- a/src/coreload/deps_format.h
+++ b/src/coreload/deps_format.h
@@ -1,6 +1,5 @@
-#ifndef DEPS_FORMAT_H
-#define DEPS_FORMAT_H
-
+#ifndef DEPS_FORMAT_H_
+#define DEPS_FORMAT_H_
 
 #include <iostream>
 #include <vector>
@@ -10,7 +9,8 @@
 #include "deps_entry.h"
 #include "cpprest/json.h"
 
-namespace coreload {
+namespace coreload
+{
     class deps_json_t
     {
         typedef web::json::value json_value;
@@ -115,4 +115,4 @@ namespace coreload {
         pal::string_t m_deps_file;
     };
 }
-#endif // DEPS_FORMAT_H
+#endif // DEPS_FORMAT_H_

--- a/src/coreload/deps_resolver.cc
+++ b/src/coreload/deps_resolver.cc
@@ -1,6 +1,3 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include <set>
 #include <functional>
 #include <cassert>
@@ -22,7 +19,8 @@ const coreload::pal::string_t ManifestListMessage = _X(
     "  This assembly was expected to be in the local runtime store as the application was published using the following target manifest files:\n"
     "    %s");
 
-namespace coreload {
+namespace coreload
+{
     // -----------------------------------------------------------------------------
     // A uniqifying append helper that doesn't let two "paths" to be identical in
     // the "output" string.
@@ -855,4 +853,4 @@ namespace coreload {
 
         return true;
     }
-}
+} // namespace coreload

--- a/src/coreload/deps_resolver.h
+++ b/src/coreload/deps_resolver.h
@@ -1,8 +1,7 @@
-#ifndef DEPS_RESOLVER_H
-#define DEPS_RESOLVER_H
+#ifndef DEPS_RESOLVER_H_
+#define DEPS_RESOLVER_H_
 
 #include <vector>
-
 #include "pal.h"
 #include "arguments.h"
 #include "trace.h"
@@ -12,7 +11,8 @@
 #include "runtime_config.h"
 #include "libhost.h"
 
-namespace coreload {
+namespace coreload
+{
     // Probe paths to be resolved for ordering
     struct probe_paths_t
     {
@@ -233,6 +233,7 @@ namespace coreload {
         // Is the deps file for an app using shared frameworks?
         bool m_is_framework_dependent;
     };
-}
 
-#endif // DEPS_RESOLVER_H
+} // namespace coreload
+
+#endif // DEPS_RESOLVER_H_

--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -4,10 +4,10 @@ int ValidateArgument(
     const pal::char_t* argument,
     size_t max_size)
 {
-    if (argument != nullptr && pal::strncmp(argument, _X(""), max_size) != 0)
+    if (argument != nullptr)
     {
         const size_t string_length = pal::strlen(argument);
-        if (string_length >= max_size)
+        if (string_length == 0 || string_length > max_size)
         {
             return StatusCode::InvalidArgFailure;
         }

--- a/src/coreload/framework_info.cc
+++ b/src/coreload/framework_info.cc
@@ -4,7 +4,8 @@
 #include "trace.h"
 #include "utils.h"
 
-namespace coreload {
+namespace coreload
+{
     bool compare_by_name_and_version(const framework_info &a, const framework_info &b)
     {
         if (a.name < b.name)
@@ -107,4 +108,4 @@ namespace coreload {
 
         return framework_infos.size() > 0;
     }
-}
+} // namespace coreload

--- a/src/coreload/framework_info.h
+++ b/src/coreload/framework_info.h
@@ -1,9 +1,10 @@
-#ifndef __FRAMEWORK_INFO_H_
-#define __FRAMEWORK_INFO_H_
+#ifndef FRAMEWORK_INFO_H_
+#define FRAMEWORK_INFO_H_
 
 #include "libhost.h"
 
-namespace coreload {
+namespace coreload
+{
     struct framework_info
     {
         framework_info(pal::string_t name, pal::string_t path, fx_ver_t version)
@@ -21,5 +22,6 @@ namespace coreload {
         pal::string_t path;
         fx_ver_t version;
     };
+
 }
-#endif // __FRAMEWORK_INFO_H_
+#endif // FRAMEWORK_INFO_H_

--- a/src/coreload/fx_definition.cc
+++ b/src/coreload/fx_definition.cc
@@ -1,6 +1,7 @@
 #include "fx_definition.h"
 
-namespace coreload {
+namespace coreload
+{
     fx_definition_t::fx_definition_t() {}
 
     fx_definition_t::fx_definition_t(
@@ -35,4 +36,4 @@ namespace coreload {
     {
         m_deps.parse(true, m_deps_file, graph);
     }
-}
+} // namespace coreload

--- a/src/coreload/fx_definition.h
+++ b/src/coreload/fx_definition.h
@@ -1,12 +1,14 @@
-#ifndef FX_DEFINITION_H
-#define FX_DEFINITION_H
+#ifndef FX_DEFINITION_H_
+#define FX_DEFINITION_H_
 
 #include "pal.h"
 #include "deps_format.h"
 #include "runtime_config.h"
 
-namespace coreload {
-    class fx_definition_t {
+namespace coreload
+{
+    class fx_definition_t
+    {
     public:
         fx_definition_t();
 
@@ -48,6 +50,7 @@ namespace coreload {
     {
         return *fx_definitions[0];
     }
-}
 
-#endif // FX_DEFINITION_H
+} // namespace coreload
+
+#endif // FX_DEFINITION_H_

--- a/src/coreload/fx_muxer.cc
+++ b/src/coreload/fx_muxer.cc
@@ -6,7 +6,8 @@
 #include "deps_resolver.h"
 #include "coreclr.h"
 
-namespace coreload {
+namespace coreload
+{
     /**
     * Resolve the hostpolicy version from deps.
     *  - Scan the deps file's libraries section and find the hostpolicy version in the file.
@@ -1063,4 +1064,4 @@ namespace coreload {
         }  
         return StatusCode::Success;
     }
-}
+} // namespace coreload

--- a/src/coreload/fx_muxer.h
+++ b/src/coreload/fx_muxer.h
@@ -1,11 +1,12 @@
-#pragma once
-#ifndef __FX_MUXER_H__
-#define __FX_MUXER_H__
+#ifndef FX_MUXER_H_
+#define FX_MUXER_H_
+
 #include "libhost.h"
 #include "arguments.h"
 #include "coreclr.h"
 
-namespace coreload {
+namespace coreload
+{
     const int Max_Framework_Resolve_Retries = 100;
 
     class corehost_init_t;
@@ -88,5 +89,7 @@ namespace coreload {
             const fx_definition_vector_t& fx_definitions,
             const fx_name_to_fx_reference_map_t& newest_references);
     };
-}
-#endif // __FX_MUXER_H__
+
+} // namespace coreload
+
+#endif // FX_MUXER_H_

--- a/src/coreload/fx_muxer.messages.cc
+++ b/src/coreload/fx_muxer.messages.cc
@@ -1,10 +1,8 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include <cassert>
 #include "fx_muxer.h"
 
-namespace coreload {
+namespace coreload
+{
     /**
     * When the framework is referenced more than once in a non-compatible way, display detailed error message
     *   about available frameworks and installation of new framework.
@@ -95,4 +93,4 @@ namespace coreload {
             }
         }
     }
-}
+} // namespace coreload

--- a/src/coreload/fx_reference.cc
+++ b/src/coreload/fx_reference.cc
@@ -1,11 +1,9 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 #include "pal.h"
 #include "fx_ver.h"
 #include "fx_reference.h"
 
-namespace coreload {
+namespace coreload
+{
     bool fx_reference_t::is_roll_forward_compatible(const fx_ver_t& other) const
     {
         // We expect the version to be <
@@ -102,4 +100,4 @@ namespace coreload {
             }
         }
     }
-}
+} // namespace coreload

--- a/src/coreload/fx_reference.h
+++ b/src/coreload/fx_reference.h
@@ -1,15 +1,13 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-#ifndef __FX_REFERENCE_H__
-#define __FX_REFERENCE_H__
+#ifndef FX_REFERENCE_H_
+#define FX_REFERENCE_H_
 
 #include <list>
 #include "pal.h"
 #include "fx_ver.h"
 #include "roll_fwd_on_no_candidate_fx_option.h"
 
-namespace coreload {
+namespace coreload 
+{
     class fx_reference_t
     {
     public:
@@ -104,5 +102,7 @@ namespace coreload {
 
     typedef std::vector<fx_reference_t> fx_reference_vector_t;
     typedef std::unordered_map<pal::string_t, fx_reference_t> fx_name_to_fx_reference_map_t;
-}
-#endif // __FX_REFERENCE_H__
+
+} // namespace coreload
+
+#endif // FX_REFERENCE_H_

--- a/src/coreload/fx_ver.cc
+++ b/src/coreload/fx_ver.cc
@@ -3,7 +3,8 @@
 #include "utils.h"
 #include "fx_ver.h"
 
-namespace coreload {
+namespace coreload
+{
     fx_ver_t::fx_ver_t(int major, int minor, int patch, const pal::string_t& pre, const pal::string_t& build)
         : m_major(major)
         , m_minor(minor)
@@ -196,4 +197,4 @@ namespace coreload {
         assert(!valid || fx_ver->as_str() == ver);
         return valid;
     }
-}
+} // namespace coreload

--- a/src/coreload/fx_ver.h
+++ b/src/coreload/fx_ver.h
@@ -1,9 +1,10 @@
-#ifndef __FX_VER_H__
-#define __FX_VER_H__
+#ifndef FX_VER_H_
+#define FX_VER_H_
 
 #include "pal.h"
 
-namespace coreload {
+namespace coreload
+{
     // Note: This is not SemVer (esp., in comparing pre-release part, fx_ver_t does not
     // compare multiple dot separated identifiers individually.) ex: 1.0.0-beta.2 vs. 1.0.0-beta.11
     struct fx_ver_t
@@ -45,5 +46,7 @@ namespace coreload {
 
         static int compare(const fx_ver_t&a, const fx_ver_t& b);
     };
-}
-#endif // __FX_VER_H__
+
+} // namespace coreload
+
+#endif // FX_VER_H_

--- a/src/coreload/host_startup_info.cc
+++ b/src/coreload/host_startup_info.cc
@@ -4,7 +4,8 @@
 #include "status_code.h"
 #include "utils.h"
 
-namespace coreload {
+namespace coreload
+{
     host_startup_info_t::host_startup_info_t(
         const pal::char_t* host_path_value,
         const pal::char_t* dotnet_root_value,
@@ -88,4 +89,4 @@ namespace coreload {
 
         return 0;
     }
-}
+} // namespace coreload

--- a/src/coreload/host_startup_info.h
+++ b/src/coreload/host_startup_info.h
@@ -1,10 +1,12 @@
-#ifndef HOST_STARTUP_INFO_H
-#define HOST_STARTUP_INFO_H
+#ifndef HOST_STARTUP_INFO_H_
+#define HOST_STARTUP_INFO_H_
 
 #include "pal.h"
 
-namespace coreload {
-    class host_startup_info_t {
+namespace coreload
+{
+    class host_startup_info_t
+    {
     public:
         host_startup_info_t() {}
         host_startup_info_t(
@@ -26,5 +28,7 @@ namespace coreload {
         pal::string_t dotnet_root;  // The path to the framework.
         pal::string_t app_path;     // For apphost, the path to the app dll; for muxer, not applicable as this information is not yet parsed.
     };
-}
-#endif // HOST_STARTUP_INFO_H
+
+} // namespace coreload
+
+#endif // HOST_STARTUP_INFO_H_

--- a/src/coreload/libhost.cc
+++ b/src/coreload/libhost.cc
@@ -4,8 +4,8 @@
 #include "libhost.h"
 #include "host_startup_info.h"
 
-namespace coreload {
-
+namespace coreload
+{
     void get_runtime_config_paths_from_app(const pal::string_t& app, pal::string_t* cfg, pal::string_t* dev_cfg)
     {
         auto name = get_filename_without_ext(app);
@@ -145,4 +145,4 @@ namespace coreload {
             trace::verbose(_X("Prerelease roll forwarded [%s] -> [%s] in [%s]"), start_str.c_str(), max_str->c_str(), path.c_str());
         }
     }
-}
+} // namespace coreload

--- a/src/coreload/libhost.h
+++ b/src/coreload/libhost.h
@@ -1,5 +1,5 @@
-#ifndef LIBHOST_H
-#define LIBHOST_H
+#ifndef LIBHOST_H_
+#define LIBHOST_H_
 
 #include <stdint.h>
 #include "trace.h"
@@ -8,7 +8,8 @@
 #include "fx_definition.h"
 #include "fx_ver.h"
 
-namespace coreload {
+namespace coreload
+{
     enum host_mode_t
     {
         invalid = 0,
@@ -411,4 +412,5 @@ namespace coreload {
     void try_prerelease_roll_forward_in_dir(const pal::string_t& cur_dir, const fx_ver_t& start_ver, pal::string_t* max_str);
 
 } // namespace coreload
-#endif // LIBHOST_H
+
+#endif // LIBHOST_H_

--- a/src/coreload/roll_fwd_on_no_candidate_fx_option.h
+++ b/src/coreload/roll_fwd_on_no_candidate_fx_option.h
@@ -1,10 +1,8 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#ifndef ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_
+#define ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_
 
-#ifndef __ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_
-#define __ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_
-
-namespace coreload {
+namespace coreload
+{
     // Specifies the roll forward capability for finding the closest (most compatible) framework
     // Note that the "applyPatches" bool option is separate from this and occurs after roll forward.
     enum class roll_fwd_on_no_candidate_fx_option
@@ -13,6 +11,7 @@ namespace coreload {
         minor,          // also inludes patch
         major           // also inludes minor and patch
     };
-}
 
-#endif // __ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_
+} // namespace coreload
+
+#endif // ROLL_FWD_ON_NO_CANDIDATE_FX_OPTION_H_

--- a/src/coreload/runtime_config.cc
+++ b/src/coreload/runtime_config.cc
@@ -6,7 +6,8 @@
 #include "fx_reference.h"
 #include <cassert>
 
-namespace coreload {
+namespace coreload
+{
     // The semantics of applying the runtimeconfig.json values follows, in the following steps from
     // first to last, where last always wins. These steps are also annotated in the code here.
     // 1) Apply the environment settings
@@ -340,4 +341,4 @@ namespace coreload {
         m_frameworks[0].set_roll_fwd_on_no_candidate_fx(roll_fwd_on_no_candidate_fx_option::disabled);
         m_frameworks[0].set_use_exact_version(true);
     }
-}
+} // namespace coreload

--- a/src/coreload/runtime_config.h
+++ b/src/coreload/runtime_config.h
@@ -1,6 +1,5 @@
-#pragma once
-#ifndef __RUNTIME_CONFIG_H__
-#define __RUNTIME_CONFIG_H__
+#ifndef RUNTIME_CONFIG_H_
+#define RUNTIME_CONFIG_H_
 
 #include "pal.h"
 #include "cpprest/json.h"
@@ -9,7 +8,8 @@
 typedef web::json::value json_value;
 typedef web::json::object json_object;
 
-namespace coreload {
+namespace coreload
+{
     class runtime_config_framework_t
     {
     public:
@@ -105,5 +105,6 @@ namespace coreload {
         bool read_framework_array(web::json::array frameworks);
         static void copy_framework_settings_to(const fx_reference_t& from, fx_reference_t& to);
     };
-}
-#endif // __RUNTIME_CONFIG_H__
+} // namespace coreload
+
+#endif // RUNTIME_CONFIG_H_

--- a/src/coreload/status_code.h
+++ b/src/coreload/status_code.h
@@ -1,7 +1,8 @@
-#ifndef STATUS_CODE_H
-#define STATUS_CODE_H
+#ifndef STATUS_CODE_H_
+#define STATUS_CODE_H_
 
-namespace coreload {
+namespace coreload
+{
     enum StatusCode
     {
         Success = 0,
@@ -35,5 +36,7 @@ namespace coreload {
         FrameworkCompatFailure = 0x8000809c,
         FrameworkCompatRetry = 0x8000809d,
     };
-}
-#endif // STATUS_CODE_H
+
+} // namespace coreload
+
+#endif // STATUS_CODE_H_

--- a/src/coreload/version.cc
+++ b/src/coreload/version.cc
@@ -8,7 +8,8 @@
 // -- if version_t is an empty value (-1 for all segments) then as_str() returns an empty string
 // -- Different terminology; fx_ver_t(major, minor, patch, build) vs version_t(major, minor, build, revision)
 
-namespace coreload {
+namespace coreload
+{
     version_t::version_t() : version_t(-1, -1, -1, -1) { }
 
     version_t::version_t(int major, int minor, int build, int revision)
@@ -165,4 +166,4 @@ namespace coreload {
         assert(!valid || ver_out->as_str() == ver);
         return valid;
     }
-}
+} // namespace coreload

--- a/src/coreload/version.h
+++ b/src/coreload/version.h
@@ -1,10 +1,11 @@
-#ifndef VERSION_H
-#define VERSION_H
+#ifndef VERSION_H_
+#define VERSION_H_
 
 #include "pal.h"
 #include "utils.h"
 
-namespace coreload {
+namespace coreload
+{
     struct version_t
     {
         version_t();
@@ -39,5 +40,7 @@ namespace coreload {
 
         static int compare(const version_t&a, const version_t& b);
     };
-}
-#endif // VERSION_H
+
+} // namespace coreload
+
+#endif // VERSION_H_


### PR DESCRIPTION
Make the header include guards and namespace declarations more consistent across the project library code.

Also remove an unneeded empty string check since we also verify the string length, we can just use that.