### PR TITLE
Fix DLL argument string length check max 

### DIFF
--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -7,7 +7,7 @@ int ValidateArgument(
     if (argument != nullptr)
     {
         const size_t string_length = pal::strlen(argument);
-        if (string_length == 0 || string_length > max_size)
+        if (string_length == 0 || string_length >= max_size)
         {
             return StatusCode::InvalidArgFailure;
         }

--- a/src/coreload/dll/coreload.h
+++ b/src/coreload/dll/coreload.h
@@ -1,6 +1,5 @@
-#pragma once
-#ifndef CORELOAD_DLL_H
-#define CORELOAD_DLL_H
+#ifndef CORELOAD_DLL_H_
+#define CORELOAD_DLL_H_
 
 #include "targetver.h"
 #include "deps_resolver.h"
@@ -65,4 +64,4 @@ SHARED_API int StartCoreCLR(const core_host_arguments* arguments);
 // Stop the .NET Core host in the current application
 SHARED_API int UnloadRuntime();
 
-#endif // CORELOAD_DLL_H
+#endif // CORELOAD_DLL_H_

--- a/src/coreload/fx_muxer.cc
+++ b/src/coreload/fx_muxer.cc
@@ -717,6 +717,13 @@ namespace coreload
         pal::string_t roll_fwd_on_no_candidate_fx;
         pal::string_t additional_deps;
         pal::string_t deps_file = _X("");
+
+        // If the assembly doesn't exist, exit.
+        if (!pal::realpath(&arguments.managed_application))
+        {
+            return StatusCode::InvalidArgFailure;
+        }
+
         pal::string_t runtime_config = host_info.dotnet_root;
         append_path(&runtime_config, _X("dotnet.runtimeconfig.json"));
 


### PR DESCRIPTION
* Validate the assembly path before initializing the runtime.
* Update name and file path checks to be within the expect bounds instead of off-by-one.