### PR TITLE
Use explicit namespaces instead of the using directive

### DIFF
--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -1,53 +1,53 @@
 #include "coreload.h"
 
 int ValidateArgument(
-    const pal::char_t* argument,
+    const ::coreload::pal::char_t* argument,
     size_t max_size)
 {
     if (argument != nullptr)
     {
-        const size_t string_length = pal::strnlen(argument, max_size);
+        const size_t string_length = ::coreload::pal::strnlen(argument, max_size);
         if (string_length == 0 || string_length >= max_size)
         {
-            return StatusCode::InvalidArgFailure;
+            return ::coreload::StatusCode::InvalidArgFailure;
         }
     }
     else
     {
-        return StatusCode::InvalidArgFailure;
+        return ::coreload::StatusCode::InvalidArgFailure;
     }
-    return StatusCode::Success;
+    return ::coreload::StatusCode::Success;
 }
 
 bool inline IsValidCoreHostArgument(
-    const pal::char_t* argument,
+    const ::coreload::pal::char_t* argument,
     size_t max_size)
 {
-    return ValidateArgument(argument, max_size) == StatusCode::Success;
+    return ValidateArgument(argument, max_size) == ::coreload::StatusCode::Success;
 }
 
 // Start the .NET Core runtime in the current application
 int StartCoreCLRInternal(
-    const pal::char_t*  assembly_path,
-    const pal::char_t*  core_root,
+    const coreload::pal::char_t*  assembly_path,
+    const coreload::pal::char_t*  core_root,
     const unsigned char verbose_log)
 {
     if (verbose_log)
     {
-        trace::enable();
+        coreload::trace::enable();
     }
-    host_startup_info_t startup_info;
-    arguments_t arguments;
+    coreload::host_startup_info_t startup_info;
+    coreload::arguments_t arguments;
   
     startup_info.dotnet_root = core_root;
 
     arguments.managed_application = assembly_path;
-    arguments.app_root = get_directory(arguments.managed_application);
+    arguments.app_root = coreload::get_directory(arguments.managed_application);
 
-    return corehost::initialize_clr(
+    return coreload::corehost::initialize_clr(
         arguments,
         startup_info,
-        host_mode_t::muxer);
+        coreload::host_mode_t::muxer);
 }
 
 // Host the .NET Core runtime in the current application
@@ -58,7 +58,7 @@ SHARED_API int StartCoreCLR(
         || !IsValidCoreHostArgument(arguments->assembly_file_path, MAX_PATH)
         || !IsValidCoreHostArgument(arguments->core_root_path, MAX_PATH))
     {
-        return StatusCode::InvalidArgFailure;
+        return coreload::StatusCode::InvalidArgFailure;
     }
 
     return StartCoreCLRInternal(arguments->assembly_file_path, arguments->core_root_path, arguments->verbose);
@@ -71,7 +71,7 @@ SHARED_API int CreateAssemblyDelegate(
     const char* method_name,
     void**      pfnDelegate)
 {
-    return corehost::create_delegate(
+    return coreload::corehost::create_delegate(
         assembly_name,
         type_name,
         method_name,
@@ -86,7 +86,7 @@ int ExecuteAssemblyClassFunction(
     const char* entry,
     const unsigned char* arguments)
 {
-    int exit_code = StatusCode::HostApiFailed;
+    int exit_code = coreload::StatusCode::HostApiFailed;
     typedef void (STDMETHODCALLTYPE load_plugin_fn)(const void *load_plugin_arguments);
     load_plugin_fn* load_plugin_delegate = nullptr;
 
@@ -112,7 +112,7 @@ int ExecuteAssemblyClassFunction(
     }
     else
     {
-        exit_code = StatusCode::InvalidArgFailure;
+        exit_code = coreload::StatusCode::InvalidArgFailure;
     }
     return exit_code;
 }
@@ -125,13 +125,13 @@ SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments)
         || !IsValidCoreHostArgument(arguments->class_name, max_function_name_size)
         || !IsValidCoreHostArgument(arguments->function_name, max_function_name_size))
     {
-        return StatusCode::InvalidArgFailure;
+        return coreload::StatusCode::InvalidArgFailure;
     }
 
     std::vector<char> assembly_name, class_name, function_name;
-    pal::pal_clrstring(arguments->assembly_name, &assembly_name);
-    pal::pal_clrstring(arguments->class_name, &class_name);
-    pal::pal_clrstring(arguments->function_name, &function_name);
+    coreload::pal::pal_clrstring(arguments->assembly_name, &assembly_name);
+    coreload::pal::pal_clrstring(arguments->class_name, &class_name);
+    coreload::pal::pal_clrstring(arguments->function_name, &function_name);
 
     return ExecuteAssemblyClassFunction(assembly_name.data(), class_name.data(), function_name.data(), arguments->arguments);
 }
@@ -139,7 +139,7 @@ SHARED_API int ExecuteAssemblyFunction(const assembly_function_call* arguments)
 // Shutdown the .NET Core runtime
 SHARED_API int UnloadRuntime()
 {
-    return corehost::unload_runtime();
+    return coreload::corehost::unload_runtime();
 }
 
 BOOL APIENTRY DllMain(

--- a/src/coreload/dll/coreload.cc
+++ b/src/coreload/dll/coreload.cc
@@ -1,29 +1,29 @@
 #include "coreload.h"
 
 int ValidateArgument(
-    const ::coreload::pal::char_t* argument,
+    const coreload::pal::char_t* argument,
     size_t max_size)
 {
     if (argument != nullptr)
     {
-        const size_t string_length = ::coreload::pal::strnlen(argument, max_size);
+        const size_t string_length = coreload::pal::strnlen(argument, max_size);
         if (string_length == 0 || string_length >= max_size)
         {
-            return ::coreload::StatusCode::InvalidArgFailure;
+            return coreload::StatusCode::InvalidArgFailure;
         }
     }
     else
     {
-        return ::coreload::StatusCode::InvalidArgFailure;
+        return coreload::StatusCode::InvalidArgFailure;
     }
-    return ::coreload::StatusCode::Success;
+    return coreload::StatusCode::Success;
 }
 
 bool inline IsValidCoreHostArgument(
-    const ::coreload::pal::char_t* argument,
+    const coreload::pal::char_t* argument,
     size_t max_size)
 {
-    return ValidateArgument(argument, max_size) == ::coreload::StatusCode::Success;
+    return ValidateArgument(argument, max_size) == coreload::StatusCode::Success;
 }
 
 // Start the .NET Core runtime in the current application

--- a/src/coreload/dll/coreload.h
+++ b/src/coreload/dll/coreload.h
@@ -12,25 +12,23 @@
 // The max length of arguments to be parsed and passed to a .NET function
 #define assembly_function_arguments_size        12
 
-using namespace coreload;
-
 // Arguments for hosting the .NET Core runtime and loading an assembly into the
 struct core_host_arguments
 {
-    unsigned char verbose;
-    unsigned char reserved[7];
-    pal::char_t   assembly_file_path[MAX_PATH];
-    pal::char_t   core_root_path[MAX_PATH];
+    unsigned char           verbose;
+    unsigned char           reserved[7];
+    coreload::pal::char_t   assembly_file_path[MAX_PATH];
+    coreload::pal::char_t   core_root_path[MAX_PATH];
 };
 
 // Arguments for executing a function located in a .NET assembly,
 // with optional arguments passed to the function call
 struct assembly_function_call
 {
-    pal::char_t   assembly_name[max_function_name_size];
-    pal::char_t   class_name[max_function_name_size];
-    pal::char_t   function_name[max_function_name_size];
-    unsigned char arguments[assembly_function_arguments_size];
+    coreload::pal::char_t   assembly_name[max_function_name_size];
+    coreload::pal::char_t   class_name[max_function_name_size];
+    coreload::pal::char_t   function_name[max_function_name_size];
+    unsigned char           arguments[assembly_function_arguments_size];
 };
 
 struct core_load_arguments

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -252,22 +252,3 @@ TEST(TestLibraryExports, TestStartCoreCLRWithInvalidAssemblyPath)
 
     EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
 }
-
-TEST(TestLibraryExports, TestStartCoreCLRWithEmptyAssemblyPath2)
-{
-    core_host_arguments host_arguments = { 0 };
-
-    const auto empty_string = _X("a");
-    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
-    wcscpy_s(host_arguments.core_root_path, MAX_PATH, _X("C:\\"));
-
-    wcscpy_s(host_arguments.assembly_file_path,
-        MAX_PATH,
-        _X("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
-
-    host_arguments.assembly_file_path[255] = 'a';
-    host_arguments.assembly_file_path[256] = 'a';
-   // auto len = pal::strlen(host_arguments.assembly_file_path);
-
-    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
-}

--- a/tests/coreload_test.cc
+++ b/tests/coreload_test.cc
@@ -23,8 +23,8 @@ TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly)
     WCHAR dotnet_root[MAX_PATH];
     ExpandEnvironmentStringsW(dotnet_sdk_root, dotnet_root, MAX_PATH);
 
-    pal::string_t library_path = dotnet_assembly_name;
-    ASSERT_TRUE(pal::realpath(&library_path));
+    coreload::pal::string_t library_path = dotnet_assembly_name;
+    ASSERT_TRUE(coreload::pal::realpath(&library_path));
 
     core_host_arguments host_arguments = { 0 };
     // The path to the assembly being loaded by CoreCLR.
@@ -113,13 +113,13 @@ TEST(ExecuteDotnetAssemblyTest, CanExecuteDotnetAssembly)
 
     assembly_function_call assembly_function_call = { 0 };
 
-    pal::string_t assembly_name_wide;
-    pal::string_t type_name_wide;
-    pal::string_t method_name_wide;
+    coreload::pal::string_t assembly_name_wide;
+    coreload::pal::string_t type_name_wide;
+    coreload::pal::string_t method_name_wide;
 
-    pal::utf8_palstring(assembly_name, &assembly_name_wide);
-    pal::utf8_palstring(type_name, &type_name_wide);
-    pal::utf8_palstring(method_name_load, &method_name_wide);
+    coreload::pal::utf8_palstring(assembly_name, &assembly_name_wide);
+    coreload::pal::utf8_palstring(type_name, &type_name_wide);
+    coreload::pal::utf8_palstring(method_name_load, &method_name_wide);
 
     wcscpy_s(assembly_function_call.assembly_name, max_function_name_size, assembly_name_wide.c_str());
     wcscpy_s(assembly_function_call.class_name, max_function_name_size, type_name_wide.c_str());
@@ -135,9 +135,9 @@ TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName)
 {
     assembly_function_call assembly_function_call = { 0 };
 
-    pal::string_t assembly_name_wide;
-    pal::string_t type_name_wide;
-    pal::string_t method_name_wide;
+    coreload::pal::string_t assembly_name_wide;
+    coreload::pal::string_t type_name_wide;
+    coreload::pal::string_t method_name_wide;
 
     const auto empty_string = _X("");
 
@@ -145,16 +145,16 @@ TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyAssemblyName)
     wcscpy_s(assembly_function_call.class_name, max_function_name_size, _X("ClassName"));
     wcscpy_s(assembly_function_call.function_name, max_function_name_size, _X("MethodName"));
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
 TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassName)
 {
     assembly_function_call assembly_function_call = { 0 };
 
-    pal::string_t assembly_name_wide;
-    pal::string_t type_name_wide;
-    pal::string_t method_name_wide;
+    coreload::pal::string_t assembly_name_wide;
+    coreload::pal::string_t type_name_wide;
+    coreload::pal::string_t method_name_wide;
 
     const auto empty_string = _X("");
 
@@ -162,16 +162,16 @@ TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassName)
     wcscpy_s(assembly_function_call.class_name, max_function_name_size, empty_string);
     wcscpy_s(assembly_function_call.function_name, max_function_name_size, _X("MethodName"));
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
 TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName)
 {
     assembly_function_call assembly_function_call = { 0 };
 
-    pal::string_t assembly_name_wide;
-    pal::string_t type_name_wide;
-    pal::string_t method_name_wide;
+    coreload::pal::string_t assembly_name_wide;
+    coreload::pal::string_t type_name_wide;
+    coreload::pal::string_t method_name_wide;
 
     const auto empty_string = _X("");
 
@@ -179,16 +179,16 @@ TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithOneEmptyClassMethodName)
     wcscpy_s(assembly_function_call.class_name, max_function_name_size, _X("ClassName"));
     wcscpy_s(assembly_function_call.function_name, max_function_name_size, empty_string);
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
 TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithEmptyArguments)
 {
     assembly_function_call assembly_function_call = { 0 };
 
-    pal::string_t assembly_name_wide;
-    pal::string_t type_name_wide;
-    pal::string_t method_name_wide;
+    coreload::pal::string_t assembly_name_wide;
+    coreload::pal::string_t type_name_wide;
+    coreload::pal::string_t method_name_wide;
 
     const auto empty_string = _X("");
 
@@ -196,7 +196,7 @@ TEST(LibraryExportsTest, TestExecuteAssemblyFunctionWithEmptyArguments)
     wcscpy_s(assembly_function_call.class_name, max_function_name_size, empty_string);
     wcscpy_s(assembly_function_call.function_name, max_function_name_size, empty_string);
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(&assembly_function_call));
 }
 
 TEST(LibraryExportsTest, TestStartCoreCLRWithEmptyArguments)
@@ -207,7 +207,7 @@ TEST(LibraryExportsTest, TestStartCoreCLRWithEmptyArguments)
     wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
     wcscpy_s(host_arguments.core_root_path, MAX_PATH, empty_string);
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
 }
 
 TEST(TestLibraryExports, TestStartCoreCLRWithEmptyAssemblyPath)
@@ -218,7 +218,7 @@ TEST(TestLibraryExports, TestStartCoreCLRWithEmptyAssemblyPath)
     wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
     wcscpy_s(host_arguments.core_root_path, MAX_PATH, _X("C:\\"));
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
 }
 
 TEST(TestLibraryExports, TestStartCoreCLRWithEmptyCoreRootPath)
@@ -229,15 +229,45 @@ TEST(TestLibraryExports, TestStartCoreCLRWithEmptyCoreRootPath)
     wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, _X("C:\\"));
     wcscpy_s(host_arguments.core_root_path, MAX_PATH, empty_string);
 
-    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
 }
 
 TEST(TestLibraryExports, TestExecuteAssemblyFunctionWithNullArguments)
 {
-    EXPECT_EQ(StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(nullptr));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, ExecuteAssemblyFunction(nullptr));
 }
 
 TEST(TestLibraryExports, TestStartCoreCLRWithNullArguments)
 {
-    EXPECT_EQ(StatusCode::InvalidArgFailure, StartCoreCLR(nullptr));
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(nullptr));
+}
+
+TEST(TestLibraryExports, TestStartCoreCLRWithInvalidAssemblyPath)
+{
+    core_host_arguments host_arguments = { 0 };
+
+    const auto invalid_file_path = _X("^-.3this_is_not_a_file_path");
+    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, invalid_file_path);
+    wcscpy_s(host_arguments.core_root_path, MAX_PATH, _X("C:\\"));
+
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
+}
+
+TEST(TestLibraryExports, TestStartCoreCLRWithEmptyAssemblyPath2)
+{
+    core_host_arguments host_arguments = { 0 };
+
+    const auto empty_string = _X("a");
+    wcscpy_s(host_arguments.assembly_file_path, MAX_PATH, empty_string);
+    wcscpy_s(host_arguments.core_root_path, MAX_PATH, _X("C:\\"));
+
+    wcscpy_s(host_arguments.assembly_file_path,
+        MAX_PATH,
+        _X("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+
+    host_arguments.assembly_file_path[255] = 'a';
+    host_arguments.assembly_file_path[256] = 'a';
+   // auto len = pal::strlen(host_arguments.assembly_file_path);
+
+    EXPECT_EQ(coreload::StatusCode::InvalidArgFailure, StartCoreCLR(&host_arguments));
 }


### PR DESCRIPTION
No need for the using directive since there aren't that many lines of code for the DLL, we can just use the explicit namespace in the DLL source.